### PR TITLE
fix: fix DefaultValue definition and hide some nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -57,14 +57,14 @@ export default grammar({
 		),
 
 		operation_rest: $ => seq(
-			optional($.operation_name),
+			optional($._operation_name),
 			'(',
 			$.argument_list,
 			')',
 			';'
 		),
 
-		operation_name: $ => choice(
+		_operation_name: $ => choice(
 			$.operation_name_keyword,
 			$.identifier,
 		),
@@ -106,17 +106,17 @@ export default grammar({
 			seq(
 				'optional',
 				field('type', $.type_with_extended_attributes),
-				field('name', $.argument_name),
+				field('name', $._argument_name),
 				optional($.default),
 			),
 			seq(
 				field('type', $.type),
 				optional($.ellipsis),
-				field('name', $.argument_name),
+				field('name', $._argument_name),
 			),
 		),
 
-		argument_name: $ => choice(
+		_argument_name: $ => choice(
 			$.argument_name_keyword,
 			$.identifier,
 		),
@@ -231,7 +231,7 @@ export default grammar({
 		// default values
 		default: $ => seq('=', $.default_value),
 		default_value: $ => choice(
-			'ConstValue',
+			$._const_value,
 			$.string,
 			seq('[', ']'),
 			seq('{', '}'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -98,7 +98,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "operation_name"
+              "name": "_operation_name"
             },
             {
               "type": "BLANK"
@@ -123,7 +123,7 @@
         }
       ]
     },
-    "operation_name": {
+    "_operation_name": {
       "type": "CHOICE",
       "members": [
         {
@@ -293,7 +293,7 @@
               "name": "name",
               "content": {
                 "type": "SYMBOL",
-                "name": "argument_name"
+                "name": "_argument_name"
               }
             },
             {
@@ -338,14 +338,14 @@
               "name": "name",
               "content": {
                 "type": "SYMBOL",
-                "name": "argument_name"
+                "name": "_argument_name"
               }
             }
           ]
         }
       ]
     },
-    "argument_name": {
+    "_argument_name": {
       "type": "CHOICE",
       "members": [
         {
@@ -819,8 +819,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "ConstValue"
+          "type": "SYMBOL",
+          "name": "_const_value"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -34,7 +34,11 @@
         "required": true,
         "types": [
           {
-            "type": "argument_name",
+            "type": "argument_name_keyword",
+            "named": true
+          },
+          {
+            "type": "identifier",
             "named": true
           }
         ]
@@ -79,25 +83,6 @@
       "types": [
         {
           "type": "argument",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "argument_name",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "argument_name_keyword",
-          "named": true
-        },
-        {
-          "type": "identifier",
           "named": true
         }
       ]
@@ -189,6 +174,18 @@
       "multiple": false,
       "required": false,
       "types": [
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
         {
           "type": "string",
           "named": true
@@ -613,25 +610,6 @@
     }
   },
   {
-    "type": "operation_name",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "operation_name_keyword",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "operation_name_keyword",
     "named": true,
     "fields": {}
@@ -649,7 +627,11 @@
           "named": true
         },
         {
-          "type": "operation_name",
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "operation_name_keyword",
           "named": true
         }
       ]
@@ -931,10 +913,6 @@
   },
   {
     "type": "ByteString",
-    "named": false
-  },
-  {
-    "type": "ConstValue",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -15,11 +15,11 @@
 #endif
 
 #define LANGUAGE_VERSION 15
-#define STATE_COUNT 326
+#define STATE_COUNT 324
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 150
+#define SYMBOL_COUNT 149
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 93
+#define TOKEN_COUNT 92
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 8
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
@@ -63,120 +63,119 @@ enum ts_symbol_identifiers {
   anon_sym_RBRACE = 33,
   anon_sym_COLON = 34,
   anon_sym_EQ = 35,
-  anon_sym_ConstValue = 36,
-  anon_sym_LBRACK = 37,
-  anon_sym_RBRACK = 38,
-  anon_sym_null = 39,
-  anon_sym_undefined = 40,
-  anon_sym_true = 41,
-  anon_sym_false = 42,
-  anon_sym_DASHInfinity = 43,
-  anon_sym_Infinity = 44,
-  anon_sym_NaN = 45,
-  anon_sym_QMARK = 46,
-  anon_sym_any = 47,
-  anon_sym_or = 48,
-  anon_sym_sequence = 49,
-  anon_sym_LT = 50,
-  anon_sym_object = 51,
-  anon_sym_symbol = 52,
-  anon_sym_FrozenArray = 53,
-  anon_sym_ObservableArray = 54,
-  anon_sym_boolean = 55,
-  anon_sym_byte = 56,
-  anon_sym_octet = 57,
-  anon_sym_bigint = 58,
-  anon_sym_unsigned = 59,
-  anon_sym_short = 60,
-  anon_sym_long = 61,
-  anon_sym_restricted = 62,
-  anon_sym_float = 63,
-  anon_sym_double = 64,
-  anon_sym_ByteString = 65,
-  anon_sym_DOMString = 66,
-  anon_sym_USVString = 67,
-  anon_sym_promise = 68,
-  anon_sym_GT = 69,
-  anon_sym_record = 70,
-  anon_sym_ArrayBuffer = 71,
-  anon_sym_SharedArrayBuffer = 72,
-  anon_sym_DataView = 73,
-  anon_sym_Int8Array = 74,
-  anon_sym_Int16Array = 75,
-  anon_sym_Int32Array = 76,
-  anon_sym_Uint8Array = 77,
-  anon_sym_Uint16Array = 78,
-  anon_sym_Uint32Array = 79,
-  anon_sym_Uint8ClampedArray = 80,
-  anon_sym_BigInt64Array = 81,
-  anon_sym_BigUint64Array = 82,
-  anon_sym_Float16Array = 83,
-  anon_sym_Float32Array = 84,
-  anon_sym_Float64Array = 85,
-  anon_sym_STAR = 86,
-  sym__integer = 87,
-  sym__decimal = 88,
-  sym_identifier = 89,
-  sym_string = 90,
-  sym__whitespace = 91,
-  sym_comment = 92,
-  sym_source_file = 93,
-  sym__definition = 94,
-  sym_regular_operation = 95,
-  sym_operation_rest = 96,
-  sym_operation_name = 97,
-  sym_operation_name_keyword = 98,
-  sym_argument_name_keyword = 99,
-  sym_argument_list = 100,
-  sym_argument = 101,
-  sym_argument_name = 102,
-  sym_namespace_statement = 103,
-  aux_sym__namespace_members = 104,
-  sym_namespace_member = 105,
-  sym_dictionary_statement = 106,
-  aux_sym__dictionary_members = 107,
-  sym_dictionary_member = 108,
-  sym__dictionary_member_rest = 109,
-  sym_inheritance = 110,
-  sym_enum_statement = 111,
-  sym__enum_value_list = 112,
-  sym_includes_statement = 113,
-  sym_const_statement = 114,
-  sym__const_type = 115,
-  sym__const_value = 116,
-  sym_default = 117,
-  sym_default_value = 118,
-  sym_integer_literal = 119,
-  sym_boolean_literal = 120,
-  sym_float_literal = 121,
-  sym_typedef_statement = 122,
-  sym_type = 123,
-  sym_type_with_extended_attributes = 124,
-  sym__single_type = 125,
-  sym_union_type = 126,
-  sym_union_or_expression = 127,
-  sym_union_member_type = 128,
-  sym_distinguishable_type = 129,
-  sym_primitive_type = 130,
-  sym_integer_type = 131,
-  sym_float_type = 132,
-  sym_string_type = 133,
-  sym_promise_type = 134,
-  sym_record_type = 135,
-  sym_buffer_related_type = 136,
-  sym_extended_attribute_list = 137,
-  sym_extended_attribute = 138,
-  sym_extended_attribute_no_args = 139,
-  sym_extended_attribute_named_arg_list = 140,
-  sym_extended_attribute_ident = 141,
-  sym_extended_attribute_ident_list = 142,
-  sym_extended_attribute_wildcard = 143,
-  sym_identifier_list = 144,
-  aux_sym_source_file_repeat1 = 145,
-  aux_sym_argument_list_repeat1 = 146,
-  aux_sym__enum_value_list_repeat1 = 147,
-  aux_sym_extended_attribute_list_repeat1 = 148,
-  aux_sym_identifier_list_repeat1 = 149,
+  anon_sym_LBRACK = 36,
+  anon_sym_RBRACK = 37,
+  anon_sym_null = 38,
+  anon_sym_undefined = 39,
+  anon_sym_true = 40,
+  anon_sym_false = 41,
+  anon_sym_DASHInfinity = 42,
+  anon_sym_Infinity = 43,
+  anon_sym_NaN = 44,
+  anon_sym_QMARK = 45,
+  anon_sym_any = 46,
+  anon_sym_or = 47,
+  anon_sym_sequence = 48,
+  anon_sym_LT = 49,
+  anon_sym_object = 50,
+  anon_sym_symbol = 51,
+  anon_sym_FrozenArray = 52,
+  anon_sym_ObservableArray = 53,
+  anon_sym_boolean = 54,
+  anon_sym_byte = 55,
+  anon_sym_octet = 56,
+  anon_sym_bigint = 57,
+  anon_sym_unsigned = 58,
+  anon_sym_short = 59,
+  anon_sym_long = 60,
+  anon_sym_restricted = 61,
+  anon_sym_float = 62,
+  anon_sym_double = 63,
+  anon_sym_ByteString = 64,
+  anon_sym_DOMString = 65,
+  anon_sym_USVString = 66,
+  anon_sym_promise = 67,
+  anon_sym_GT = 68,
+  anon_sym_record = 69,
+  anon_sym_ArrayBuffer = 70,
+  anon_sym_SharedArrayBuffer = 71,
+  anon_sym_DataView = 72,
+  anon_sym_Int8Array = 73,
+  anon_sym_Int16Array = 74,
+  anon_sym_Int32Array = 75,
+  anon_sym_Uint8Array = 76,
+  anon_sym_Uint16Array = 77,
+  anon_sym_Uint32Array = 78,
+  anon_sym_Uint8ClampedArray = 79,
+  anon_sym_BigInt64Array = 80,
+  anon_sym_BigUint64Array = 81,
+  anon_sym_Float16Array = 82,
+  anon_sym_Float32Array = 83,
+  anon_sym_Float64Array = 84,
+  anon_sym_STAR = 85,
+  sym__integer = 86,
+  sym__decimal = 87,
+  sym_identifier = 88,
+  sym_string = 89,
+  sym__whitespace = 90,
+  sym_comment = 91,
+  sym_source_file = 92,
+  sym__definition = 93,
+  sym_regular_operation = 94,
+  sym_operation_rest = 95,
+  sym__operation_name = 96,
+  sym_operation_name_keyword = 97,
+  sym_argument_name_keyword = 98,
+  sym_argument_list = 99,
+  sym_argument = 100,
+  sym__argument_name = 101,
+  sym_namespace_statement = 102,
+  aux_sym__namespace_members = 103,
+  sym_namespace_member = 104,
+  sym_dictionary_statement = 105,
+  aux_sym__dictionary_members = 106,
+  sym_dictionary_member = 107,
+  sym__dictionary_member_rest = 108,
+  sym_inheritance = 109,
+  sym_enum_statement = 110,
+  sym__enum_value_list = 111,
+  sym_includes_statement = 112,
+  sym_const_statement = 113,
+  sym__const_type = 114,
+  sym__const_value = 115,
+  sym_default = 116,
+  sym_default_value = 117,
+  sym_integer_literal = 118,
+  sym_boolean_literal = 119,
+  sym_float_literal = 120,
+  sym_typedef_statement = 121,
+  sym_type = 122,
+  sym_type_with_extended_attributes = 123,
+  sym__single_type = 124,
+  sym_union_type = 125,
+  sym_union_or_expression = 126,
+  sym_union_member_type = 127,
+  sym_distinguishable_type = 128,
+  sym_primitive_type = 129,
+  sym_integer_type = 130,
+  sym_float_type = 131,
+  sym_string_type = 132,
+  sym_promise_type = 133,
+  sym_record_type = 134,
+  sym_buffer_related_type = 135,
+  sym_extended_attribute_list = 136,
+  sym_extended_attribute = 137,
+  sym_extended_attribute_no_args = 138,
+  sym_extended_attribute_named_arg_list = 139,
+  sym_extended_attribute_ident = 140,
+  sym_extended_attribute_ident_list = 141,
+  sym_extended_attribute_wildcard = 142,
+  sym_identifier_list = 143,
+  aux_sym_source_file_repeat1 = 144,
+  aux_sym_argument_list_repeat1 = 145,
+  aux_sym__enum_value_list_repeat1 = 146,
+  aux_sym_extended_attribute_list_repeat1 = 147,
+  aux_sym_identifier_list_repeat1 = 148,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -216,7 +215,6 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RBRACE] = "}",
   [anon_sym_COLON] = ":",
   [anon_sym_EQ] = "=",
-  [anon_sym_ConstValue] = "ConstValue",
   [anon_sym_LBRACK] = "[",
   [anon_sym_RBRACK] = "]",
   [anon_sym_null] = "null",
@@ -277,12 +275,12 @@ static const char * const ts_symbol_names[] = {
   [sym__definition] = "_definition",
   [sym_regular_operation] = "regular_operation",
   [sym_operation_rest] = "operation_rest",
-  [sym_operation_name] = "operation_name",
+  [sym__operation_name] = "_operation_name",
   [sym_operation_name_keyword] = "operation_name_keyword",
   [sym_argument_name_keyword] = "argument_name_keyword",
   [sym_argument_list] = "argument_list",
   [sym_argument] = "argument",
-  [sym_argument_name] = "argument_name",
+  [sym__argument_name] = "_argument_name",
   [sym_namespace_statement] = "namespace_statement",
   [aux_sym__namespace_members] = "_namespace_members",
   [sym_namespace_member] = "namespace_member",
@@ -369,7 +367,6 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RBRACE] = anon_sym_RBRACE,
   [anon_sym_COLON] = anon_sym_COLON,
   [anon_sym_EQ] = anon_sym_EQ,
-  [anon_sym_ConstValue] = anon_sym_ConstValue,
   [anon_sym_LBRACK] = anon_sym_LBRACK,
   [anon_sym_RBRACK] = anon_sym_RBRACK,
   [anon_sym_null] = anon_sym_null,
@@ -430,12 +427,12 @@ static const TSSymbol ts_symbol_map[] = {
   [sym__definition] = sym__definition,
   [sym_regular_operation] = sym_regular_operation,
   [sym_operation_rest] = sym_operation_rest,
-  [sym_operation_name] = sym_operation_name,
+  [sym__operation_name] = sym__operation_name,
   [sym_operation_name_keyword] = sym_operation_name_keyword,
   [sym_argument_name_keyword] = sym_argument_name_keyword,
   [sym_argument_list] = sym_argument_list,
   [sym_argument] = sym_argument,
-  [sym_argument_name] = sym_argument_name,
+  [sym__argument_name] = sym__argument_name,
   [sym_namespace_statement] = sym_namespace_statement,
   [aux_sym__namespace_members] = aux_sym__namespace_members,
   [sym_namespace_member] = sym_namespace_member,
@@ -627,10 +624,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_EQ] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_ConstValue] = {
     .visible = true,
     .named = false,
   },
@@ -875,8 +868,8 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_operation_name] = {
-    .visible = true,
+  [sym__operation_name] = {
+    .visible = false,
     .named = true,
   },
   [sym_operation_name_keyword] = {
@@ -895,8 +888,8 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_argument_name] = {
-    .visible = true,
+  [sym__argument_name] = {
+    .visible = false,
     .named = true,
   },
   [sym_namespace_statement] = {
@@ -1193,31 +1186,31 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [17] = 17,
   [18] = 18,
   [19] = 19,
-  [20] = 15,
+  [20] = 20,
   [21] = 21,
   [22] = 22,
-  [23] = 23,
-  [24] = 15,
+  [23] = 14,
+  [24] = 17,
   [25] = 17,
-  [26] = 16,
-  [27] = 17,
-  [28] = 17,
-  [29] = 16,
-  [30] = 15,
-  [31] = 16,
+  [26] = 17,
+  [27] = 15,
+  [28] = 14,
+  [29] = 15,
+  [30] = 14,
+  [31] = 15,
   [32] = 32,
   [33] = 33,
   [34] = 34,
-  [35] = 34,
+  [35] = 35,
   [36] = 34,
-  [37] = 37,
-  [38] = 37,
-  [39] = 37,
+  [37] = 35,
+  [38] = 34,
+  [39] = 35,
   [40] = 40,
   [41] = 40,
-  [42] = 42,
+  [42] = 40,
   [43] = 40,
-  [44] = 40,
+  [44] = 44,
   [45] = 45,
   [46] = 46,
   [47] = 47,
@@ -1230,8 +1223,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [54] = 54,
   [55] = 55,
   [56] = 56,
-  [57] = 56,
-  [58] = 55,
+  [57] = 55,
+  [58] = 56,
   [59] = 59,
   [60] = 60,
   [61] = 61,
@@ -1273,138 +1266,138 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [97] = 97,
   [98] = 98,
   [99] = 99,
-  [100] = 98,
+  [100] = 100,
   [101] = 101,
-  [102] = 102,
+  [102] = 98,
   [103] = 103,
   [104] = 104,
   [105] = 105,
   [106] = 106,
   [107] = 107,
-  [108] = 70,
+  [108] = 61,
   [109] = 60,
-  [110] = 61,
-  [111] = 75,
+  [110] = 75,
+  [111] = 111,
   [112] = 65,
-  [113] = 64,
-  [114] = 62,
-  [115] = 76,
-  [116] = 116,
-  [117] = 69,
-  [118] = 68,
-  [119] = 61,
-  [120] = 69,
+  [113] = 66,
+  [114] = 67,
+  [115] = 64,
+  [116] = 77,
+  [117] = 61,
+  [118] = 75,
+  [119] = 70,
+  [120] = 73,
   [121] = 60,
-  [122] = 65,
-  [123] = 64,
-  [124] = 68,
-  [125] = 63,
-  [126] = 70,
-  [127] = 127,
-  [128] = 62,
-  [129] = 74,
-  [130] = 75,
-  [131] = 73,
-  [132] = 72,
-  [133] = 77,
-  [134] = 76,
-  [135] = 72,
-  [136] = 63,
-  [137] = 61,
-  [138] = 74,
-  [139] = 60,
-  [140] = 73,
-  [141] = 127,
-  [142] = 77,
-  [143] = 71,
-  [144] = 127,
-  [145] = 127,
-  [146] = 71,
+  [122] = 70,
+  [123] = 68,
+  [124] = 64,
+  [125] = 69,
+  [126] = 65,
+  [127] = 72,
+  [128] = 71,
+  [129] = 72,
+  [130] = 71,
+  [131] = 61,
+  [132] = 73,
+  [133] = 74,
+  [134] = 68,
+  [135] = 69,
+  [136] = 66,
+  [137] = 74,
+  [138] = 138,
+  [139] = 67,
+  [140] = 76,
+  [141] = 77,
+  [142] = 60,
+  [143] = 111,
+  [144] = 111,
+  [145] = 111,
+  [146] = 76,
   [147] = 147,
-  [148] = 80,
+  [148] = 83,
   [149] = 149,
-  [150] = 62,
-  [151] = 74,
-  [152] = 78,
-  [153] = 61,
-  [154] = 73,
-  [155] = 72,
-  [156] = 79,
-  [157] = 77,
-  [158] = 76,
-  [159] = 159,
-  [160] = 84,
-  [161] = 82,
+  [150] = 150,
+  [151] = 151,
+  [152] = 152,
+  [153] = 153,
+  [154] = 154,
+  [155] = 155,
+  [156] = 156,
+  [157] = 82,
+  [158] = 158,
+  [159] = 85,
+  [160] = 160,
+  [161] = 78,
   [162] = 162,
   [163] = 163,
-  [164] = 164,
-  [165] = 81,
-  [166] = 166,
-  [167] = 80,
-  [168] = 60,
-  [169] = 169,
+  [164] = 65,
+  [165] = 66,
+  [166] = 67,
+  [167] = 77,
+  [168] = 75,
+  [169] = 70,
   [170] = 170,
-  [171] = 81,
-  [172] = 82,
+  [171] = 60,
+  [172] = 68,
   [173] = 173,
-  [174] = 79,
-  [175] = 175,
-  [176] = 176,
-  [177] = 177,
-  [178] = 178,
-  [179] = 179,
-  [180] = 180,
-  [181] = 65,
-  [182] = 182,
+  [174] = 69,
+  [175] = 81,
+  [176] = 71,
+  [177] = 72,
+  [178] = 80,
+  [179] = 73,
+  [180] = 74,
+  [181] = 181,
+  [182] = 79,
   [183] = 183,
-  [184] = 64,
-  [185] = 78,
-  [186] = 68,
+  [184] = 83,
+  [185] = 82,
+  [186] = 186,
   [187] = 187,
   [188] = 188,
-  [189] = 180,
-  [190] = 83,
-  [191] = 85,
-  [192] = 192,
-  [193] = 193,
-  [194] = 188,
-  [195] = 63,
-  [196] = 70,
-  [197] = 71,
-  [198] = 83,
-  [199] = 199,
-  [200] = 75,
+  [189] = 79,
+  [190] = 190,
+  [191] = 80,
+  [192] = 61,
+  [193] = 187,
+  [194] = 173,
+  [195] = 195,
+  [196] = 196,
+  [197] = 81,
+  [198] = 198,
+  [199] = 84,
+  [200] = 78,
   [201] = 201,
   [202] = 202,
   [203] = 203,
   [204] = 204,
   [205] = 205,
   [206] = 206,
-  [207] = 83,
+  [207] = 207,
   [208] = 208,
   [209] = 209,
-  [210] = 201,
-  [211] = 204,
-  [212] = 212,
+  [210] = 210,
+  [211] = 211,
+  [212] = 83,
   [213] = 82,
-  [214] = 201,
-  [215] = 204,
-  [216] = 201,
-  [217] = 204,
-  [218] = 201,
-  [219] = 219,
-  [220] = 220,
-  [221] = 221,
-  [222] = 222,
-  [223] = 223,
+  [214] = 79,
+  [215] = 215,
+  [216] = 202,
+  [217] = 217,
+  [218] = 218,
+  [219] = 215,
+  [220] = 202,
+  [221] = 215,
+  [222] = 202,
+  [223] = 215,
   [224] = 224,
   [225] = 225,
   [226] = 226,
-  [227] = 227,
+  [227] = 215,
   [228] = 228,
-  [229] = 81,
+  [229] = 229,
   [230] = 230,
-  [231] = 231,
+  [231] = 76,
   [232] = 232,
   [233] = 233,
   [234] = 234,
@@ -1413,7 +1406,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [237] = 237,
   [238] = 238,
   [239] = 239,
-  [240] = 240,
+  [240] = 232,
   [241] = 241,
   [242] = 242,
   [243] = 243,
@@ -1423,7 +1416,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [247] = 247,
   [248] = 248,
   [249] = 249,
-  [250] = 230,
+  [250] = 250,
   [251] = 251,
   [252] = 252,
   [253] = 253,
@@ -1440,65 +1433,63 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [264] = 264,
   [265] = 265,
   [266] = 266,
-  [267] = 267,
+  [267] = 237,
   [268] = 268,
   [269] = 269,
-  [270] = 270,
-  [271] = 271,
-  [272] = 272,
-  [273] = 273,
+  [270] = 257,
+  [271] = 265,
+  [272] = 252,
+  [273] = 258,
   [274] = 274,
-  [275] = 266,
-  [276] = 276,
-  [277] = 277,
-  [278] = 278,
-  [279] = 272,
-  [280] = 273,
-  [281] = 274,
-  [282] = 266,
-  [283] = 283,
-  [284] = 284,
-  [285] = 269,
-  [286] = 272,
-  [287] = 274,
-  [288] = 266,
-  [289] = 272,
-  [290] = 274,
+  [275] = 275,
+  [276] = 237,
+  [277] = 257,
+  [278] = 265,
+  [279] = 252,
+  [280] = 280,
+  [281] = 281,
+  [282] = 282,
+  [283] = 237,
+  [284] = 257,
+  [285] = 252,
+  [286] = 258,
+  [287] = 287,
+  [288] = 288,
+  [289] = 289,
+  [290] = 290,
   [291] = 291,
   [292] = 292,
   [293] = 293,
   [294] = 294,
-  [295] = 273,
+  [295] = 295,
   [296] = 296,
   [297] = 297,
   [298] = 298,
   [299] = 299,
-  [300] = 269,
+  [300] = 300,
   [301] = 301,
   [302] = 302,
-  [303] = 303,
-  [304] = 304,
-  [305] = 236,
-  [306] = 251,
-  [307] = 302,
-  [308] = 299,
-  [309] = 236,
-  [310] = 251,
-  [311] = 302,
-  [312] = 299,
-  [313] = 236,
-  [314] = 302,
-  [315] = 299,
-  [316] = 316,
+  [303] = 264,
+  [304] = 256,
+  [305] = 232,
+  [306] = 282,
+  [307] = 264,
+  [308] = 256,
+  [309] = 309,
+  [310] = 282,
+  [311] = 264,
+  [312] = 232,
+  [313] = 282,
+  [314] = 293,
+  [315] = 315,
+  [316] = 293,
   [317] = 317,
-  [318] = 230,
+  [318] = 293,
   [319] = 319,
-  [320] = 230,
-  [321] = 321,
-  [322] = 255,
-  [323] = 255,
-  [324] = 255,
-  [325] = 269,
+  [320] = 291,
+  [321] = 291,
+  [322] = 291,
+  [323] = 258,
 };
 
 static const TSSymbol ts_supertype_symbols[SUPERTYPE_COUNT] = {
@@ -1523,288 +1514,287 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(452);
+      if (eof) ADVANCE(443);
       ADVANCE_MAP(
         '"', 1,
-        '(', 453,
-        ')', 454,
-        '*', 602,
-        ',', 507,
+        '(', 444,
+        ')', 445,
+        '*', 592,
+        ',', 498,
         '-', 13,
         '.', 15,
         '/', 10,
-        '0', 603,
-        ':', 513,
-        ';', 455,
-        '<', 532,
-        '=', 514,
-        '>', 569,
-        '?', 526,
-        'A', 318,
-        'B', 203,
-        'C', 294,
+        '0', 593,
+        ':', 504,
+        ';', 446,
+        '<', 522,
+        '=', 505,
+        '>', 559,
+        '?', 516,
+        'A', 312,
+        'B', 200,
         'D', 56,
-        'F', 241,
-        'I', 262,
-        'N', 64,
-        'O', 103,
-        'S', 202,
+        'F', 238,
+        'I', 258,
+        'N', 63,
+        'O', 101,
+        'S', 199,
         'U', 57,
-        '[', 516,
-        ']', 517,
-        'a', 263,
-        'b', 205,
-        'c', 65,
-        'd', 151,
-        'e', 271,
-        'f', 72,
-        'g', 156,
-        'i', 264,
-        'l', 296,
-        'm', 66,
-        'n', 67,
-        'o', 104,
-        'p', 70,
-        'r', 135,
-        's', 136,
-        't', 321,
-        'u', 265,
-        '{', 511,
-        '}', 512,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '[', 506,
+        ']', 507,
+        'a', 259,
+        'b', 202,
+        'c', 64,
+        'd', 148,
+        'e', 267,
+        'f', 71,
+        'g', 153,
+        'i', 260,
+        'l', 290,
+        'm', 65,
+        'n', 66,
+        'o', 102,
+        'p', 69,
+        'r', 133,
+        's', 134,
+        't', 315,
+        'u', 261,
+        '{', 502,
+        '}', 503,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(605);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(595);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(1030);
+      if (lookahead == '"') ADVANCE(1020);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '(', 453,
-        ')', 454,
-        '*', 602,
-        ',', 507,
+        '(', 444,
+        ')', 445,
+        '*', 592,
+        ',', 498,
         '/', 10,
-        '>', 569,
-        '?', 526,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '>', 559,
+        '?', 516,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 3:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        '?', 526,
-        'i', 856,
-        'l', 878,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '?', 516,
+        'i', 846,
+        'l', 868,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 4:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        '?', 526,
-        'i', 856,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '?', 516,
+        'i', 846,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 5:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        'A', 902,
-        'B', 792,
-        'D', 642,
-        'F', 824,
-        'I', 852,
-        'O', 687,
-        'S', 788,
-        'U', 643,
-        '[', 516,
-        'a', 848,
-        'b', 794,
-        'd', 874,
-        'f', 836,
-        'l', 878,
-        'o', 686,
-        'p', 904,
-        'r', 726,
-        's', 727,
-        'u', 844,
-        '}', 512,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'A', 892,
+        'B', 782,
+        'D', 632,
+        'F', 814,
+        'I', 842,
+        'O', 677,
+        'S', 778,
+        'U', 633,
+        '[', 506,
+        'a', 838,
+        'b', 784,
+        'd', 864,
+        'f', 826,
+        'l', 868,
+        'o', 676,
+        'p', 894,
+        'r', 716,
+        's', 717,
+        'u', 834,
+        '}', 503,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 6:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        'A', 902,
-        'B', 792,
-        'D', 642,
-        'F', 824,
-        'I', 852,
-        'O', 687,
-        'S', 788,
-        'U', 643,
-        '[', 516,
-        'a', 848,
-        'b', 794,
-        'd', 874,
-        'f', 836,
-        'l', 878,
-        'o', 686,
-        'p', 904,
-        'r', 733,
-        's', 727,
-        'u', 844,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'A', 892,
+        'B', 782,
+        'D', 632,
+        'F', 814,
+        'I', 842,
+        'O', 677,
+        'S', 778,
+        'U', 633,
+        '[', 506,
+        'a', 838,
+        'b', 784,
+        'd', 864,
+        'f', 826,
+        'l', 868,
+        'o', 676,
+        'p', 894,
+        'r', 723,
+        's', 717,
+        'u', 834,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 7:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        'A', 902,
-        'B', 792,
-        'D', 642,
-        'F', 824,
-        'I', 852,
-        'O', 687,
-        'S', 788,
-        'U', 643,
-        'a', 848,
-        'b', 794,
-        'c', 882,
-        'd', 874,
-        'f', 836,
-        'l', 878,
-        'o', 686,
-        'p', 904,
-        'r', 733,
-        's', 727,
-        'u', 844,
-        '}', 512,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'A', 892,
+        'B', 782,
+        'D', 632,
+        'F', 814,
+        'I', 842,
+        'O', 677,
+        'S', 778,
+        'U', 633,
+        'a', 838,
+        'b', 784,
+        'c', 872,
+        'd', 864,
+        'f', 826,
+        'l', 868,
+        'o', 676,
+        'p', 894,
+        'r', 723,
+        's', 717,
+        'u', 834,
+        '}', 503,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('e' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 8:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        'A', 902,
-        'B', 792,
-        'D', 642,
-        'F', 824,
-        'I', 852,
-        'O', 687,
-        'S', 788,
-        'U', 643,
-        'a', 848,
-        'b', 794,
-        'd', 874,
-        'f', 836,
-        'l', 878,
-        'o', 685,
-        'p', 904,
-        'r', 733,
-        's', 727,
-        'u', 844,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'A', 892,
+        'B', 782,
+        'D', 632,
+        'F', 814,
+        'I', 842,
+        'O', 677,
+        'S', 778,
+        'U', 633,
+        'a', 838,
+        'b', 784,
+        'd', 864,
+        'f', 826,
+        'l', 868,
+        'o', 675,
+        'p', 894,
+        'r', 723,
+        's', 717,
+        'u', 834,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 9:
       ADVANCE_MAP(
-        '(', 453,
+        '(', 444,
         '/', 10,
-        'A', 902,
-        'B', 792,
-        'D', 642,
-        'F', 824,
-        'I', 852,
-        'O', 687,
-        'S', 788,
-        'U', 643,
-        'a', 952,
-        'b', 794,
-        'd', 874,
-        'f', 836,
-        'l', 878,
-        'o', 686,
-        'r', 733,
-        's', 727,
-        'u', 844,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'A', 892,
+        'B', 782,
+        'D', 632,
+        'F', 814,
+        'I', 842,
+        'O', 677,
+        'S', 778,
+        'U', 633,
+        'a', 942,
+        'b', 784,
+        'd', 864,
+        'f', 826,
+        'l', 868,
+        'o', 676,
+        'r', 723,
+        's', 717,
+        'u', 834,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('C' <= lookahead && lookahead <= 'Z') ||
-          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 10:
       if (lookahead == '*') ADVANCE(12);
-      if (lookahead == '/') ADVANCE(1033);
+      if (lookahead == '/') ADVANCE(1023);
       END_STATE();
     case 11:
       if (lookahead == '*') ADVANCE(11);
-      if (lookahead == '/') ADVANCE(1032);
+      if (lookahead == '/') ADVANCE(1022);
       if (lookahead != 0) ADVANCE(12);
       END_STATE();
     case 12:
@@ -1812,119 +1802,119 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(12);
       END_STATE();
     case 13:
-      if (lookahead == '.') ADVANCE(447);
-      if (lookahead == '0') ADVANCE(603);
-      if (lookahead == 'I') ADVANCE(266);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(605);
+      if (lookahead == '.') ADVANCE(438);
+      if (lookahead == '0') ADVANCE(593);
+      if (lookahead == 'I') ADVANCE(262);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(595);
       END_STATE();
     case 14:
       if (lookahead == '.') ADVANCE(17);
       END_STATE();
     case 15:
       if (lookahead == '.') ADVANCE(17);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(607);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(597);
       END_STATE();
     case 16:
-      if (lookahead == '.') ADVANCE(607);
+      if (lookahead == '.') ADVANCE(597);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(446);
+          lookahead == 'e') ADVANCE(437);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(16);
       END_STATE();
     case 17:
-      if (lookahead == '.') ADVANCE(510);
+      if (lookahead == '.') ADVANCE(501);
       END_STATE();
     case 18:
       ADVANCE_MAP(
         '.', 14,
         '/', 10,
-        '?', 526,
-        'a', 951,
-        'c', 664,
-        'd', 765,
-        'e', 843,
-        'g', 756,
-        'i', 846,
-        'l', 878,
-        'm', 655,
-        'n', 649,
-        'p', 650,
-        'r', 734,
-        's', 758,
-        't', 1007,
-        'u', 863,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '?', 516,
+        'a', 941,
+        'c', 654,
+        'd', 755,
+        'e', 833,
+        'g', 746,
+        'i', 836,
+        'l', 868,
+        'm', 645,
+        'n', 639,
+        'p', 640,
+        'r', 724,
+        's', 748,
+        't', 997,
+        'u', 853,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 19:
       ADVANCE_MAP(
         '.', 14,
         '/', 10,
-        '?', 526,
-        'a', 951,
-        'c', 664,
-        'd', 765,
-        'e', 843,
-        'g', 756,
-        'i', 846,
-        'm', 655,
-        'n', 649,
-        'p', 650,
-        'r', 734,
-        's', 758,
-        't', 1007,
-        'u', 863,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '?', 516,
+        'a', 941,
+        'c', 654,
+        'd', 755,
+        'e', 833,
+        'g', 746,
+        'i', 836,
+        'm', 645,
+        'n', 639,
+        'p', 640,
+        'r', 724,
+        's', 748,
+        't', 997,
+        'u', 853,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 20:
       ADVANCE_MAP(
         '/', 10,
-        '?', 526,
-        'l', 878,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        '?', 516,
+        'l', 868,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 21:
       ADVANCE_MAP(
         '/', 10,
-        'b', 794,
-        'd', 874,
-        'f', 836,
-        'l', 878,
-        'o', 707,
-        'r', 771,
-        's', 789,
-        'u', 857,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'b', 784,
+        'd', 864,
+        'f', 826,
+        'l', 868,
+        'o', 697,
+        'r', 761,
+        's', 779,
+        'u', 847,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 22:
       if (lookahead == '1') ADVANCE(31);
@@ -1975,1000 +1965,1000 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '6') ADVANCE(30);
       END_STATE();
     case 36:
-      if (lookahead == 'A') ADVANCE(349);
+      if (lookahead == 'A') ADVANCE(343);
       END_STATE();
     case 37:
-      if (lookahead == 'A') ADVANCE(351);
+      if (lookahead == 'A') ADVANCE(345);
       END_STATE();
     case 38:
-      if (lookahead == 'A') ADVANCE(352);
+      if (lookahead == 'A') ADVANCE(346);
       END_STATE();
     case 39:
-      if (lookahead == 'A') ADVANCE(353);
-      if (lookahead == 'C') ADVANCE(248);
+      if (lookahead == 'A') ADVANCE(347);
+      if (lookahead == 'C') ADVANCE(245);
       END_STATE();
     case 40:
-      if (lookahead == 'A') ADVANCE(354);
+      if (lookahead == 'A') ADVANCE(348);
       END_STATE();
     case 41:
-      if (lookahead == 'A') ADVANCE(355);
+      if (lookahead == 'A') ADVANCE(349);
       END_STATE();
     case 42:
-      if (lookahead == 'A') ADVANCE(356);
+      if (lookahead == 'A') ADVANCE(350);
       END_STATE();
     case 43:
-      if (lookahead == 'A') ADVANCE(357);
+      if (lookahead == 'A') ADVANCE(351);
       END_STATE();
     case 44:
-      if (lookahead == 'A') ADVANCE(358);
+      if (lookahead == 'A') ADVANCE(352);
       END_STATE();
     case 45:
-      if (lookahead == 'A') ADVANCE(359);
+      if (lookahead == 'A') ADVANCE(353);
       END_STATE();
     case 46:
-      if (lookahead == 'A') ADVANCE(360);
+      if (lookahead == 'A') ADVANCE(354);
       END_STATE();
     case 47:
-      if (lookahead == 'A') ADVANCE(361);
+      if (lookahead == 'A') ADVANCE(355);
       END_STATE();
     case 48:
-      if (lookahead == 'A') ADVANCE(362);
+      if (lookahead == 'A') ADVANCE(356);
       END_STATE();
     case 49:
-      if (lookahead == 'A') ADVANCE(363);
+      if (lookahead == 'A') ADVANCE(357);
       END_STATE();
     case 50:
-      if (lookahead == 'A') ADVANCE(365);
+      if (lookahead == 'A') ADVANCE(359);
       END_STATE();
     case 51:
-      if (lookahead == 'B') ADVANCE(411);
+      if (lookahead == 'B') ADVANCE(403);
       END_STATE();
     case 52:
-      if (lookahead == 'B') ADVANCE(419);
+      if (lookahead == 'B') ADVANCE(410);
       END_STATE();
     case 53:
-      if (lookahead == 'I') ADVANCE(281);
-      if (lookahead == 'U') ADVANCE(232);
+      if (lookahead == 'I') ADVANCE(277);
+      if (lookahead == 'U') ADVANCE(229);
       END_STATE();
     case 54:
       if (lookahead == 'M') ADVANCE(58);
       END_STATE();
     case 55:
-      if (lookahead == 'N') ADVANCE(525);
+      if (lookahead == 'N') ADVANCE(515);
       END_STATE();
     case 56:
       if (lookahead == 'O') ADVANCE(54);
-      if (lookahead == 'a') ADVANCE(386);
+      if (lookahead == 'a') ADVANCE(378);
       END_STATE();
     case 57:
-      if (lookahead == 'S') ADVANCE(63);
-      if (lookahead == 'i') ADVANCE(277);
+      if (lookahead == 'S') ADVANCE(62);
+      if (lookahead == 'i') ADVANCE(273);
       END_STATE();
     case 58:
-      if (lookahead == 'S') ADVANCE(394);
+      if (lookahead == 'S') ADVANCE(386);
       END_STATE();
     case 59:
-      if (lookahead == 'S') ADVANCE(405);
+      if (lookahead == 'S') ADVANCE(397);
       END_STATE();
     case 60:
-      if (lookahead == 'S') ADVANCE(407);
+      if (lookahead == 'S') ADVANCE(399);
       END_STATE();
     case 61:
-      if (lookahead == 'V') ADVANCE(217);
+      if (lookahead == 'V') ADVANCE(215);
       END_STATE();
     case 62:
-      if (lookahead == 'V') ADVANCE(86);
-      END_STATE();
-    case 63:
       if (lookahead == 'V') ADVANCE(59);
       END_STATE();
-    case 64:
+    case 63:
       if (lookahead == 'a') ADVANCE(55);
       END_STATE();
+    case 64:
+      if (lookahead == 'a') ADVANCE(241);
+      if (lookahead == 'o') ADVANCE(265);
+      END_STATE();
     case 65:
-      if (lookahead == 'a') ADVANCE(244);
-      if (lookahead == 'o') ADVANCE(286);
+      if (lookahead == 'a') ADVANCE(299);
+      if (lookahead == 'i') ADVANCE(413);
       END_STATE();
     case 66:
-      if (lookahead == 'a') ADVANCE(305);
-      if (lookahead == 'i') ADVANCE(422);
+      if (lookahead == 'a') ADVANCE(255);
+      if (lookahead == 'u') ADVANCE(244);
       END_STATE();
     case 67:
-      if (lookahead == 'a') ADVANCE(259);
-      if (lookahead == 'u') ADVANCE(247);
+      if (lookahead == 'a') ADVANCE(130);
+      if (lookahead == 'c') ADVANCE(291);
+      if (lookahead == 'q') ADVANCE(404);
+      if (lookahead == 's') ADVANCE(390);
       END_STATE();
     case 68:
-      if (lookahead == 'a') ADVANCE(132);
-      if (lookahead == 'c') ADVANCE(297);
-      if (lookahead == 'q') ADVANCE(412);
-      if (lookahead == 's') ADVANCE(398);
-      END_STATE();
-    case 69:
       if (lookahead == 'a') ADVANCE(61);
       END_STATE();
+    case 69:
+      if (lookahead == 'a') ADVANCE(319);
+      if (lookahead == 'r') ADVANCE(288);
+      END_STATE();
     case 70:
-      if (lookahead == 'a') ADVANCE(325);
-      if (lookahead == 'r') ADVANCE(293);
+      if (lookahead == 'a') ADVANCE(415);
       END_STATE();
     case 71:
-      if (lookahead == 'a') ADVANCE(424);
+      if (lookahead == 'a') ADVANCE(251);
+      if (lookahead == 'l') ADVANCE(298);
       END_STATE();
     case 72:
-      if (lookahead == 'a') ADVANCE(254);
-      if (lookahead == 'l') ADVANCE(304);
+      if (lookahead == 'a') ADVANCE(322);
       END_STATE();
     case 73:
-      if (lookahead == 'a') ADVANCE(328);
+      if (lookahead == 'a') ADVANCE(111);
       END_STATE();
     case 74:
-      if (lookahead == 'a') ADVANCE(113);
+      if (lookahead == 'a') ADVANCE(257);
       END_STATE();
     case 75:
-      if (lookahead == 'a') ADVANCE(261);
+      if (lookahead == 'a') ADVANCE(419);
       END_STATE();
     case 76:
-      if (lookahead == 'a') ADVANCE(428);
+      if (lookahead == 'a') ADVANCE(420);
       END_STATE();
     case 77:
-      if (lookahead == 'a') ADVANCE(429);
+      if (lookahead == 'a') ADVANCE(385);
+      if (lookahead == 'r') ADVANCE(210);
       END_STATE();
     case 78:
-      if (lookahead == 'a') ADVANCE(393);
-      if (lookahead == 'r') ADVANCE(213);
+      if (lookahead == 'a') ADVANCE(421);
       END_STATE();
     case 79:
-      if (lookahead == 'a') ADVANCE(430);
+      if (lookahead == 'a') ADVANCE(367);
       END_STATE();
     case 80:
-      if (lookahead == 'a') ADVANCE(431);
+      if (lookahead == 'a') ADVANCE(422);
       END_STATE();
     case 81:
-      if (lookahead == 'a') ADVANCE(374);
+      if (lookahead == 'a') ADVANCE(236);
       END_STATE();
     case 82:
-      if (lookahead == 'a') ADVANCE(239);
+      if (lookahead == 'a') ADVANCE(369);
       END_STATE();
     case 83:
-      if (lookahead == 'a') ADVANCE(433);
+      if (lookahead == 'a') ADVANCE(424);
       END_STATE();
     case 84:
-      if (lookahead == 'a') ADVANCE(376);
+      if (lookahead == 'a') ADVANCE(425);
       END_STATE();
     case 85:
-      if (lookahead == 'a') ADVANCE(434);
+      if (lookahead == 'a') ADVANCE(237);
       END_STATE();
     case 86:
-      if (lookahead == 'a') ADVANCE(256);
+      if (lookahead == 'a') ADVANCE(320);
       END_STATE();
     case 87:
-      if (lookahead == 'a') ADVANCE(326);
+      if (lookahead == 'a') ADVANCE(426);
       END_STATE();
     case 88:
-      if (lookahead == 'a') ADVANCE(435);
+      if (lookahead == 'a') ADVANCE(427);
       END_STATE();
     case 89:
-      if (lookahead == 'a') ADVANCE(240);
+      if (lookahead == 'a') ADVANCE(428);
       END_STATE();
     case 90:
-      if (lookahead == 'a') ADVANCE(436);
+      if (lookahead == 'a') ADVANCE(264);
       END_STATE();
     case 91:
-      if (lookahead == 'a') ADVANCE(437);
+      if (lookahead == 'a') ADVANCE(429);
       END_STATE();
     case 92:
-      if (lookahead == 'a') ADVANCE(268);
+      if (lookahead == 'a') ADVANCE(430);
       END_STATE();
     case 93:
-      if (lookahead == 'a') ADVANCE(438);
+      if (lookahead == 'a') ADVANCE(431);
       END_STATE();
     case 94:
-      if (lookahead == 'a') ADVANCE(439);
+      if (lookahead == 'a') ADVANCE(432);
       END_STATE();
     case 95:
-      if (lookahead == 'a') ADVANCE(440);
+      if (lookahead == 'a') ADVANCE(433);
       END_STATE();
     case 96:
-      if (lookahead == 'a') ADVANCE(441);
+      if (lookahead == 'a') ADVANCE(116);
       END_STATE();
     case 97:
-      if (lookahead == 'a') ADVANCE(442);
+      if (lookahead == 'a') ADVANCE(117);
       END_STATE();
     case 98:
-      if (lookahead == 'a') ADVANCE(118);
+      if (lookahead == 'a') ADVANCE(107);
       END_STATE();
     case 99:
-      if (lookahead == 'a') ADVANCE(119);
+      if (lookahead == 'a') ADVANCE(108);
       END_STATE();
     case 100:
-      if (lookahead == 'a') ADVANCE(109);
+      if (lookahead == 'a') ADVANCE(435);
       END_STATE();
     case 101:
-      if (lookahead == 'a') ADVANCE(110);
+      if (lookahead == 'b') ADVANCE(362);
       END_STATE();
     case 102:
-      if (lookahead == 'a') ADVANCE(444);
+      if (lookahead == 'b') ADVANCE(230);
+      if (lookahead == 'c') ADVANCE(392);
+      if (lookahead == 'p') ADVANCE(375);
+      if (lookahead == 'r') ADVANCE(519);
       END_STATE();
     case 103:
-      if (lookahead == 'b') ADVANCE(368);
+      if (lookahead == 'b') ADVANCE(409);
       END_STATE();
     case 104:
-      if (lookahead == 'b') ADVANCE(233);
-      if (lookahead == 'c') ADVANCE(400);
-      if (lookahead == 'p') ADVANCE(382);
-      if (lookahead == 'r') ADVANCE(529);
+      if (lookahead == 'b') ADVANCE(73);
       END_STATE();
     case 105:
-      if (lookahead == 'b') ADVANCE(418);
+      if (lookahead == 'b') ADVANCE(292);
       END_STATE();
     case 106:
-      if (lookahead == 'b') ADVANCE(74);
+      if (lookahead == 'b') ADVANCE(247);
       END_STATE();
     case 107:
-      if (lookahead == 'b') ADVANCE(298);
+      if (lookahead == 'b') ADVANCE(248);
       END_STATE();
     case 108:
-      if (lookahead == 'b') ADVANCE(250);
+      if (lookahead == 'b') ADVANCE(249);
       END_STATE();
     case 109:
-      if (lookahead == 'b') ADVANCE(251);
+      if (lookahead == 'c') ADVANCE(449);
       END_STATE();
     case 110:
-      if (lookahead == 'b') ADVANCE(252);
+      if (lookahead == 'c') ADVANCE(490);
       END_STATE();
     case 111:
-      if (lookahead == 'c') ADVANCE(458);
+      if (lookahead == 'c') ADVANCE(231);
       END_STATE();
     case 112:
-      if (lookahead == 'c') ADVANCE(499);
+      if (lookahead == 'c') ADVANCE(242);
+      if (lookahead == 'h') ADVANCE(158);
+      if (lookahead == 't') ADVANCE(161);
       END_STATE();
     case 113:
-      if (lookahead == 'c') ADVANCE(234);
+      if (lookahead == 'c') ADVANCE(373);
       END_STATE();
     case 114:
-      if (lookahead == 'c') ADVANCE(245);
-      if (lookahead == 'h') ADVANCE(161);
-      if (lookahead == 't') ADVANCE(164);
+      if (lookahead == 'c') ADVANCE(391);
       END_STATE();
     case 115:
-      if (lookahead == 'c') ADVANCE(380);
+      if (lookahead == 'c') ADVANCE(144);
       END_STATE();
     case 116:
-      if (lookahead == 'c') ADVANCE(399);
-      END_STATE();
-    case 117:
       if (lookahead == 'c') ADVANCE(146);
       END_STATE();
+    case 117:
+      if (lookahead == 'c') ADVANCE(147);
+      END_STATE();
     case 118:
-      if (lookahead == 'c') ADVANCE(148);
+      if (lookahead == 'c') ADVANCE(388);
       END_STATE();
     case 119:
-      if (lookahead == 'c') ADVANCE(149);
+      if (lookahead == 'c') ADVANCE(389);
       END_STATE();
     case 120:
       if (lookahead == 'c') ADVANCE(396);
       END_STATE();
     case 121:
-      if (lookahead == 'c') ADVANCE(397);
+      if (lookahead == 'd') ADVANCE(560);
       END_STATE();
     case 122:
-      if (lookahead == 'c') ADVANCE(404);
+      if (lookahead == 'd') ADVANCE(484);
       END_STATE();
     case 123:
-      if (lookahead == 'd') ADVANCE(570);
+      if (lookahead == 'd') ADVANCE(539);
       END_STATE();
     case 124:
-      if (lookahead == 'd') ADVANCE(493);
+      if (lookahead == 'd') ADVANCE(509);
       END_STATE();
     case 125:
-      if (lookahead == 'd') ADVANCE(549);
+      if (lookahead == 'd') ADVANCE(545);
       END_STATE();
     case 126:
-      if (lookahead == 'd') ADVANCE(519);
+      if (lookahead == 'd') ADVANCE(496);
       END_STATE();
     case 127:
-      if (lookahead == 'd') ADVANCE(555);
+      if (lookahead == 'd') ADVANCE(176);
+      if (lookahead == 'r') ADVANCE(175);
+      if (lookahead == 's') ADVANCE(204);
       END_STATE();
     case 128:
-      if (lookahead == 'd') ADVANCE(505);
+      if (lookahead == 'd') ADVANCE(151);
       END_STATE();
     case 129:
-      if (lookahead == 'd') ADVANCE(179);
-      if (lookahead == 'r') ADVANCE(178);
-      if (lookahead == 's') ADVANCE(207);
-      END_STATE();
-    case 130:
       if (lookahead == 'd') ADVANCE(154);
       END_STATE();
+    case 130:
+      if (lookahead == 'd') ADVANCE(294);
+      END_STATE();
     case 131:
-      if (lookahead == 'd') ADVANCE(157);
-      END_STATE();
-    case 132:
-      if (lookahead == 'd') ADVANCE(300);
-      END_STATE();
-    case 133:
       if (lookahead == 'd') ADVANCE(50);
       END_STATE();
-    case 134:
+    case 132:
       if (lookahead == 'd') ADVANCE(49);
       END_STATE();
+    case 133:
+      if (lookahead == 'e') ADVANCE(67);
+      END_STATE();
+    case 134:
+      if (lookahead == 'e') ADVANCE(303);
+      if (lookahead == 'h') ADVANCE(297);
+      if (lookahead == 't') ADVANCE(77);
+      if (lookahead == 'y') ADVANCE(254);
+      END_STATE();
     case 135:
-      if (lookahead == 'e') ADVANCE(68);
+      if (lookahead == 'e') ADVANCE(533);
       END_STATE();
     case 136:
-      if (lookahead == 'e') ADVANCE(309);
-      if (lookahead == 'h') ADVANCE(303);
-      if (lookahead == 't') ADVANCE(78);
-      if (lookahead == 'y') ADVANCE(258);
+      if (lookahead == 'e') ADVANCE(511);
       END_STATE();
     case 137:
-      if (lookahead == 'e') ADVANCE(543);
+      if (lookahead == 'e') ADVANCE(512);
       END_STATE();
     case 138:
-      if (lookahead == 'e') ADVANCE(521);
+      if (lookahead == 'e') ADVANCE(549);
       END_STATE();
     case 139:
-      if (lookahead == 'e') ADVANCE(522);
+      if (lookahead == 'e') ADVANCE(412);
       END_STATE();
     case 140:
-      if (lookahead == 'e') ADVANCE(559);
+      if (lookahead == 'e') ADVANCE(474);
       END_STATE();
     case 141:
-      if (lookahead == 'e') ADVANCE(421);
+      if (lookahead == 'e') ADVANCE(557);
       END_STATE();
     case 142:
-      if (lookahead == 'e') ADVANCE(483);
+      if (lookahead == 'e') ADVANCE(486);
       END_STATE();
     case 143:
-      if (lookahead == 'e') ADVANCE(567);
+      if (lookahead == 'e') ADVANCE(472);
       END_STATE();
     case 144:
-      if (lookahead == 'e') ADVANCE(495);
+      if (lookahead == 'e') ADVANCE(520);
       END_STATE();
     case 145:
-      if (lookahead == 'e') ADVANCE(481);
+      if (lookahead == 'e') ADVANCE(451);
       END_STATE();
     case 146:
-      if (lookahead == 'e') ADVANCE(530);
+      if (lookahead == 'e') ADVANCE(470);
       END_STATE();
     case 147:
-      if (lookahead == 'e') ADVANCE(460);
+      if (lookahead == 'e') ADVANCE(478);
       END_STATE();
     case 148:
-      if (lookahead == 'e') ADVANCE(479);
+      if (lookahead == 'e') ADVANCE(250);
+      if (lookahead == 'i') ADVANCE(120);
+      if (lookahead == 'o') ADVANCE(401);
       END_STATE();
     case 149:
-      if (lookahead == 'e') ADVANCE(487);
+      if (lookahead == 'e') ADVANCE(128);
       END_STATE();
     case 150:
-      if (lookahead == 'e') ADVANCE(515);
+      if (lookahead == 'e') ADVANCE(361);
       END_STATE();
     case 151:
-      if (lookahead == 'e') ADVANCE(253);
-      if (lookahead == 'i') ADVANCE(122);
-      if (lookahead == 'o') ADVANCE(409);
+      if (lookahead == 'e') ADVANCE(182);
       END_STATE();
     case 152:
-      if (lookahead == 'e') ADVANCE(130);
+      if (lookahead == 'e') ADVANCE(131);
       END_STATE();
     case 153:
-      if (lookahead == 'e') ADVANCE(367);
+      if (lookahead == 'e') ADVANCE(393);
       END_STATE();
     case 154:
-      if (lookahead == 'e') ADVANCE(185);
+      if (lookahead == 'e') ADVANCE(360);
       END_STATE();
     case 155:
-      if (lookahead == 'e') ADVANCE(133);
+      if (lookahead == 'e') ADVANCE(122);
       END_STATE();
     case 156:
-      if (lookahead == 'e') ADVANCE(401);
+      if (lookahead == 'e') ADVANCE(304);
       END_STATE();
     case 157:
-      if (lookahead == 'e') ADVANCE(366);
+      if (lookahead == 'e') ADVANCE(123);
       END_STATE();
     case 158:
-      if (lookahead == 'e') ADVANCE(124);
+      if (lookahead == 'e') ADVANCE(326);
       END_STATE();
     case 159:
-      if (lookahead == 'e') ADVANCE(310);
+      if (lookahead == 'e') ADVANCE(90);
       END_STATE();
     case 160:
-      if (lookahead == 'e') ADVANCE(125);
+      if (lookahead == 'e') ADVANCE(124);
       END_STATE();
     case 161:
-      if (lookahead == 'e') ADVANCE(332);
+      if (lookahead == 'e') ADVANCE(313);
       END_STATE();
     case 162:
-      if (lookahead == 'e') ADVANCE(92);
+      if (lookahead == 'e') ADVANCE(125);
       END_STATE();
     case 163:
       if (lookahead == 'e') ADVANCE(126);
       END_STATE();
     case 164:
-      if (lookahead == 'e') ADVANCE(319);
+      if (lookahead == 'e') ADVANCE(305);
       END_STATE();
     case 165:
-      if (lookahead == 'e') ADVANCE(127);
+      if (lookahead == 'e') ADVANCE(306);
       END_STATE();
     case 166:
-      if (lookahead == 'e') ADVANCE(128);
+      if (lookahead == 'e') ADVANCE(284);
       END_STATE();
     case 167:
-      if (lookahead == 'e') ADVANCE(311);
+      if (lookahead == 'e') ADVANCE(307);
       END_STATE();
     case 168:
-      if (lookahead == 'e') ADVANCE(312);
+      if (lookahead == 'e') ADVANCE(370);
       END_STATE();
     case 169:
-      if (lookahead == 'e') ADVANCE(289);
+      if (lookahead == 'e') ADVANCE(308);
       END_STATE();
     case 170:
-      if (lookahead == 'e') ADVANCE(313);
+      if (lookahead == 'e') ADVANCE(271);
       END_STATE();
     case 171:
-      if (lookahead == 'e') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(310);
       END_STATE();
     case 172:
-      if (lookahead == 'e') ADVANCE(314);
+      if (lookahead == 'e') ADVANCE(311);
       END_STATE();
     case 173:
-      if (lookahead == 'e') ADVANCE(275);
+      if (lookahead == 'e') ADVANCE(113);
       END_STATE();
     case 174:
-      if (lookahead == 'e') ADVANCE(316);
+      if (lookahead == 'e') ADVANCE(318);
       END_STATE();
     case 175:
-      if (lookahead == 'e') ADVANCE(317);
+      if (lookahead == 'e') ADVANCE(366);
       END_STATE();
     case 176:
-      if (lookahead == 'e') ADVANCE(115);
+      if (lookahead == 'e') ADVANCE(186);
       END_STATE();
     case 177:
-      if (lookahead == 'e') ADVANCE(324);
+      if (lookahead == 'e') ADVANCE(395);
       END_STATE();
     case 178:
-      if (lookahead == 'e') ADVANCE(373);
+      if (lookahead == 'e') ADVANCE(132);
       END_STATE();
     case 179:
-      if (lookahead == 'e') ADVANCE(189);
-      END_STATE();
-    case 180:
-      if (lookahead == 'e') ADVANCE(403);
-      END_STATE();
-    case 181:
-      if (lookahead == 'e') ADVANCE(134);
-      END_STATE();
-    case 182:
       if (lookahead == 'e') ADVANCE(60);
       END_STATE();
-    case 183:
+    case 180:
       if (lookahead == 'e') ADVANCE(48);
       END_STATE();
-    case 184:
-      if (lookahead == 'f') ADVANCE(210);
+    case 181:
+      if (lookahead == 'f') ADVANCE(207);
       if (lookahead == 't') ADVANCE(22);
       END_STATE();
+    case 182:
+      if (lookahead == 'f') ADVANCE(494);
+      END_STATE();
+    case 183:
+      if (lookahead == 'f') ADVANCE(187);
+      END_STATE();
+    case 184:
+      if (lookahead == 'f') ADVANCE(96);
+      END_STATE();
     case 185:
-      if (lookahead == 'f') ADVANCE(503);
+      if (lookahead == 'f') ADVANCE(226);
       END_STATE();
     case 186:
-      if (lookahead == 'f') ADVANCE(190);
+      if (lookahead == 'f') ADVANCE(222);
       END_STATE();
     case 187:
-      if (lookahead == 'f') ADVANCE(98);
+      if (lookahead == 'f') ADVANCE(169);
       END_STATE();
     case 188:
-      if (lookahead == 'f') ADVANCE(229);
-      END_STATE();
-    case 189:
-      if (lookahead == 'f') ADVANCE(224);
-      END_STATE();
-    case 190:
       if (lookahead == 'f') ADVANCE(172);
       END_STATE();
+    case 189:
+      if (lookahead == 'f') ADVANCE(188);
+      END_STATE();
+    case 190:
+      if (lookahead == 'f') ADVANCE(228);
+      END_STATE();
     case 191:
-      if (lookahead == 'f') ADVANCE(175);
-      END_STATE();
-    case 192:
-      if (lookahead == 'f') ADVANCE(191);
-      END_STATE();
-    case 193:
-      if (lookahead == 'f') ADVANCE(231);
-      END_STATE();
-    case 194:
       if (lookahead == 'g') ADVANCE(53);
       END_STATE();
-    case 195:
+    case 192:
+      if (lookahead == 'g') ADVANCE(543);
+      END_STATE();
+    case 193:
       if (lookahead == 'g') ADVANCE(553);
       END_STATE();
+    case 194:
+      if (lookahead == 'g') ADVANCE(555);
+      END_STATE();
+    case 195:
+      if (lookahead == 'g') ADVANCE(551);
+      END_STATE();
     case 196:
-      if (lookahead == 'g') ADVANCE(563);
+      if (lookahead == 'g') ADVANCE(219);
       END_STATE();
     case 197:
-      if (lookahead == 'g') ADVANCE(565);
+      if (lookahead == 'g') ADVANCE(279);
       END_STATE();
     case 198:
-      if (lookahead == 'g') ADVANCE(561);
+      if (lookahead == 'g') ADVANCE(224);
       END_STATE();
     case 199:
-      if (lookahead == 'g') ADVANCE(221);
+      if (lookahead == 'h') ADVANCE(72);
       END_STATE();
     case 200:
-      if (lookahead == 'g') ADVANCE(283);
+      if (lookahead == 'i') ADVANCE(191);
+      if (lookahead == 'y') ADVANCE(379);
       END_STATE();
     case 201:
-      if (lookahead == 'g') ADVANCE(227);
+      if (lookahead == 'i') ADVANCE(232);
       END_STATE();
     case 202:
-      if (lookahead == 'h') ADVANCE(73);
+      if (lookahead == 'i') ADVANCE(198);
+      if (lookahead == 'o') ADVANCE(287);
+      if (lookahead == 'y') ADVANCE(382);
       END_STATE();
     case 203:
-      if (lookahead == 'i') ADVANCE(194);
-      if (lookahead == 'y') ADVANCE(387);
+      if (lookahead == 'i') ADVANCE(110);
       END_STATE();
     case 204:
-      if (lookahead == 'i') ADVANCE(235);
+      if (lookahead == 'i') ADVANCE(197);
       END_STATE();
     case 205:
-      if (lookahead == 'i') ADVANCE(201);
-      if (lookahead == 'o') ADVANCE(292);
-      if (lookahead == 'y') ADVANCE(390);
+      if (lookahead == 'i') ADVANCE(103);
       END_STATE();
     case 206:
-      if (lookahead == 'i') ADVANCE(112);
+      if (lookahead == 'i') ADVANCE(118);
       END_STATE();
     case 207:
-      if (lookahead == 'i') ADVANCE(200);
+      if (lookahead == 'i') ADVANCE(275);
       END_STATE();
     case 208:
-      if (lookahead == 'i') ADVANCE(105);
+      if (lookahead == 'i') ADVANCE(81);
       END_STATE();
     case 209:
-      if (lookahead == 'i') ADVANCE(120);
+      if (lookahead == 'i') ADVANCE(263);
       END_STATE();
     case 210:
-      if (lookahead == 'i') ADVANCE(279);
+      if (lookahead == 'i') ADVANCE(269);
       END_STATE();
     case 211:
-      if (lookahead == 'i') ADVANCE(82);
+      if (lookahead == 'i') ADVANCE(380);
       END_STATE();
     case 212:
-      if (lookahead == 'i') ADVANCE(267);
+      if (lookahead == 'i') ADVANCE(270);
       END_STATE();
     case 213:
-      if (lookahead == 'i') ADVANCE(273);
+      if (lookahead == 'i') ADVANCE(374);
       END_STATE();
     case 214:
-      if (lookahead == 'i') ADVANCE(274);
+      if (lookahead == 'i') ADVANCE(272);
       END_STATE();
     case 215:
-      if (lookahead == 'i') ADVANCE(388);
+      if (lookahead == 'i') ADVANCE(139);
       END_STATE();
     case 216:
-      if (lookahead == 'i') ADVANCE(276);
+      if (lookahead == 'i') ADVANCE(383);
       END_STATE();
     case 217:
-      if (lookahead == 'i') ADVANCE(141);
+      if (lookahead == 'i') ADVANCE(274);
       END_STATE();
     case 218:
-      if (lookahead == 'i') ADVANCE(381);
+      if (lookahead == 'i') ADVANCE(293);
       END_STATE();
     case 219:
-      if (lookahead == 'i') ADVANCE(278);
+      if (lookahead == 'i') ADVANCE(185);
       END_STATE();
     case 220:
-      if (lookahead == 'i') ADVANCE(391);
+      if (lookahead == 'i') ADVANCE(233);
       END_STATE();
     case 221:
-      if (lookahead == 'i') ADVANCE(188);
+      if (lookahead == 'i') ADVANCE(324);
       END_STATE();
     case 222:
-      if (lookahead == 'i') ADVANCE(236);
+      if (lookahead == 'i') ADVANCE(280);
       END_STATE();
     case 223:
-      if (lookahead == 'i') ADVANCE(330);
+      if (lookahead == 'i') ADVANCE(365);
       END_STATE();
     case 224:
-      if (lookahead == 'i') ADVANCE(284);
+      if (lookahead == 'i') ADVANCE(278);
       END_STATE();
     case 225:
-      if (lookahead == 'i') ADVANCE(299);
+      if (lookahead == 'i') ADVANCE(296);
       END_STATE();
     case 226:
-      if (lookahead == 'i') ADVANCE(372);
+      if (lookahead == 'i') ADVANCE(171);
       END_STATE();
     case 227:
-      if (lookahead == 'i') ADVANCE(282);
+      if (lookahead == 'i') ADVANCE(119);
       END_STATE();
     case 228:
-      if (lookahead == 'i') ADVANCE(302);
+      if (lookahead == 'i') ADVANCE(283);
       END_STATE();
     case 229:
-      if (lookahead == 'i') ADVANCE(174);
+      if (lookahead == 'i') ADVANCE(285);
       END_STATE();
     case 230:
-      if (lookahead == 'i') ADVANCE(121);
+      if (lookahead == 'j') ADVANCE(173);
       END_STATE();
     case 231:
-      if (lookahead == 'i') ADVANCE(288);
+      if (lookahead == 'k') ADVANCE(453);
       END_STATE();
     case 232:
-      if (lookahead == 'i') ADVANCE(290);
+      if (lookahead == 'k') ADVANCE(140);
       END_STATE();
     case 233:
-      if (lookahead == 'j') ADVANCE(176);
-      END_STATE();
-    case 234:
-      if (lookahead == 'k') ADVANCE(462);
-      END_STATE();
-    case 235:
       if (lookahead == 'k') ADVANCE(142);
       END_STATE();
-    case 236:
-      if (lookahead == 'k') ADVANCE(144);
-      END_STATE();
-    case 237:
-      if (lookahead == 'l') ADVANCE(518);
-      END_STATE();
-    case 238:
-      if (lookahead == 'l') ADVANCE(535);
-      END_STATE();
-    case 239:
-      if (lookahead == 'l') ADVANCE(489);
-      END_STATE();
-    case 240:
+    case 234:
       if (lookahead == 'l') ADVANCE(508);
       END_STATE();
+    case 235:
+      if (lookahead == 'l') ADVANCE(525);
+      END_STATE();
+    case 236:
+      if (lookahead == 'l') ADVANCE(480);
+      END_STATE();
+    case 237:
+      if (lookahead == 'l') ADVANCE(499);
+      END_STATE();
+    case 238:
+      if (lookahead == 'l') ADVANCE(289);
+      if (lookahead == 'r') ADVANCE(286);
+      END_STATE();
+    case 239:
+      if (lookahead == 'l') ADVANCE(104);
+      END_STATE();
+    case 240:
+      if (lookahead == 'l') ADVANCE(417);
+      END_STATE();
     case 241:
-      if (lookahead == 'l') ADVANCE(295);
-      if (lookahead == 'r') ADVANCE(291);
+      if (lookahead == 'l') ADVANCE(239);
       END_STATE();
     case 242:
-      if (lookahead == 'l') ADVANCE(106);
+      if (lookahead == 'l') ADVANCE(407);
       END_STATE();
     case 243:
-      if (lookahead == 'l') ADVANCE(426);
+      if (lookahead == 'l') ADVANCE(201);
       END_STATE();
     case 244:
-      if (lookahead == 'l') ADVANCE(242);
+      if (lookahead == 'l') ADVANCE(234);
       END_STATE();
     case 245:
-      if (lookahead == 'l') ADVANCE(416);
+      if (lookahead == 'l') ADVANCE(74);
       END_STATE();
     case 246:
-      if (lookahead == 'l') ADVANCE(204);
+      if (lookahead == 'l') ADVANCE(159);
       END_STATE();
     case 247:
-      if (lookahead == 'l') ADVANCE(237);
+      if (lookahead == 'l') ADVANCE(138);
       END_STATE();
     case 248:
-      if (lookahead == 'l') ADVANCE(75);
+      if (lookahead == 'l') ADVANCE(143);
       END_STATE();
     case 249:
-      if (lookahead == 'l') ADVANCE(162);
-      END_STATE();
-    case 250:
-      if (lookahead == 'l') ADVANCE(140);
-      END_STATE();
-    case 251:
-      if (lookahead == 'l') ADVANCE(145);
-      END_STATE();
-    case 252:
-      if (lookahead == 'l') ADVANCE(183);
-      END_STATE();
-    case 253:
       if (lookahead == 'l') ADVANCE(180);
       END_STATE();
+    case 250:
+      if (lookahead == 'l') ADVANCE(177);
+      END_STATE();
+    case 251:
+      if (lookahead == 'l') ADVANCE(364);
+      END_STATE();
+    case 252:
+      if (lookahead == 'l') ADVANCE(220);
+      if (lookahead == 't') ADVANCE(165);
+      END_STATE();
+    case 253:
+      if (lookahead == 'm') ADVANCE(464);
+      END_STATE();
     case 254:
-      if (lookahead == 'l') ADVANCE(371);
+      if (lookahead == 'm') ADVANCE(105);
       END_STATE();
     case 255:
-      if (lookahead == 'l') ADVANCE(222);
-      if (lookahead == 't') ADVANCE(168);
+      if (lookahead == 'm') ADVANCE(150);
       END_STATE();
     case 256:
-      if (lookahead == 'l') ADVANCE(415);
+      if (lookahead == 'm') ADVANCE(223);
       END_STATE();
     case 257:
-      if (lookahead == 'm') ADVANCE(473);
+      if (lookahead == 'm') ADVANCE(302);
       END_STATE();
     case 258:
-      if (lookahead == 'm') ADVANCE(107);
+      if (lookahead == 'n') ADVANCE(181);
       END_STATE();
     case 259:
-      if (lookahead == 'm') ADVANCE(153);
+      if (lookahead == 'n') ADVANCE(414);
+      if (lookahead == 's') ADVANCE(434);
+      if (lookahead == 't') ADVANCE(381);
       END_STATE();
     case 260:
-      if (lookahead == 'm') ADVANCE(226);
+      if (lookahead == 'n') ADVANCE(112);
+      if (lookahead == 't') ADVANCE(174);
       END_STATE();
     case 261:
-      if (lookahead == 'm') ADVANCE(308);
+      if (lookahead == 'n') ADVANCE(127);
       END_STATE();
     case 262:
-      if (lookahead == 'n') ADVANCE(184);
+      if (lookahead == 'n') ADVANCE(190);
       END_STATE();
     case 263:
-      if (lookahead == 'n') ADVANCE(423);
-      if (lookahead == 's') ADVANCE(443);
-      if (lookahead == 't') ADVANCE(389);
+      if (lookahead == 'n') ADVANCE(476);
       END_STATE();
     case 264:
-      if (lookahead == 'n') ADVANCE(114);
-      if (lookahead == 't') ADVANCE(177);
+      if (lookahead == 'n') ADVANCE(531);
       END_STATE();
     case 265:
-      if (lookahead == 'n') ADVANCE(129);
+      if (lookahead == 'n') ADVANCE(363);
       END_STATE();
     case 266:
-      if (lookahead == 'n') ADVANCE(193);
+      if (lookahead == 'n') ADVANCE(109);
       END_STATE();
     case 267:
-      if (lookahead == 'n') ADVANCE(485);
+      if (lookahead == 'n') ADVANCE(402);
       END_STATE();
     case 268:
-      if (lookahead == 'n') ADVANCE(541);
+      if (lookahead == 'n') ADVANCE(192);
       END_STATE();
     case 269:
-      if (lookahead == 'n') ADVANCE(369);
-      END_STATE();
-    case 270:
-      if (lookahead == 'n') ADVANCE(111);
-      END_STATE();
-    case 271:
-      if (lookahead == 'n') ADVANCE(410);
-      END_STATE();
-    case 272:
-      if (lookahead == 'n') ADVANCE(195);
-      END_STATE();
-    case 273:
-      if (lookahead == 'n') ADVANCE(199);
-      END_STATE();
-    case 274:
       if (lookahead == 'n') ADVANCE(196);
       END_STATE();
+    case 270:
+      if (lookahead == 'n') ADVANCE(193);
+      END_STATE();
+    case 271:
+      if (lookahead == 'n') ADVANCE(115);
+      END_STATE();
+    case 272:
+      if (lookahead == 'n') ADVANCE(194);
+      END_STATE();
+    case 273:
+      if (lookahead == 'n') ADVANCE(376);
+      END_STATE();
+    case 274:
+      if (lookahead == 'n') ADVANCE(195);
+      END_STATE();
     case 275:
-      if (lookahead == 'n') ADVANCE(117);
+      if (lookahead == 'n') ADVANCE(211);
       END_STATE();
     case 276:
-      if (lookahead == 'n') ADVANCE(197);
+      if (lookahead == 'n') ADVANCE(240);
       END_STATE();
     case 277:
-      if (lookahead == 'n') ADVANCE(383);
+      if (lookahead == 'n') ADVANCE(377);
       END_STATE();
     case 278:
-      if (lookahead == 'n') ADVANCE(198);
+      if (lookahead == 'n') ADVANCE(372);
       END_STATE();
     case 279:
-      if (lookahead == 'n') ADVANCE(215);
+      if (lookahead == 'n') ADVANCE(157);
       END_STATE();
     case 280:
-      if (lookahead == 'n') ADVANCE(243);
-      END_STATE();
-    case 281:
-      if (lookahead == 'n') ADVANCE(384);
-      END_STATE();
-    case 282:
-      if (lookahead == 'n') ADVANCE(379);
-      END_STATE();
-    case 283:
       if (lookahead == 'n') ADVANCE(160);
       END_STATE();
+    case 281:
+      if (lookahead == 'n') ADVANCE(86);
+      END_STATE();
+    case 282:
+      if (lookahead == 'n') ADVANCE(85);
+      END_STATE();
+    case 283:
+      if (lookahead == 'n') ADVANCE(216);
+      END_STATE();
     case 284:
-      if (lookahead == 'n') ADVANCE(163);
-      END_STATE();
-    case 285:
-      if (lookahead == 'n') ADVANCE(87);
-      END_STATE();
-    case 286:
-      if (lookahead == 'n') ADVANCE(370);
-      END_STATE();
-    case 287:
-      if (lookahead == 'n') ADVANCE(89);
-      END_STATE();
-    case 288:
-      if (lookahead == 'n') ADVANCE(220);
-      END_STATE();
-    case 289:
       if (lookahead == 'n') ADVANCE(40);
       END_STATE();
+    case 285:
+      if (lookahead == 'n') ADVANCE(400);
+      END_STATE();
+    case 286:
+      if (lookahead == 'o') ADVANCE(436);
+      END_STATE();
+    case 287:
+      if (lookahead == 'o') ADVANCE(246);
+      END_STATE();
+    case 288:
+      if (lookahead == 'o') ADVANCE(256);
+      END_STATE();
+    case 289:
+      if (lookahead == 'o') ADVANCE(79);
+      END_STATE();
     case 290:
-      if (lookahead == 'n') ADVANCE(408);
+      if (lookahead == 'o') ADVANCE(268);
       END_STATE();
     case 291:
-      if (lookahead == 'o') ADVANCE(445);
+      if (lookahead == 'o') ADVANCE(317);
       END_STATE();
     case 292:
-      if (lookahead == 'o') ADVANCE(249);
+      if (lookahead == 'o') ADVANCE(235);
       END_STATE();
     case 293:
-      if (lookahead == 'o') ADVANCE(260);
+      if (lookahead == 'o') ADVANCE(282);
       END_STATE();
     case 294:
-      if (lookahead == 'o') ADVANCE(269);
+      if (lookahead == 'o') ADVANCE(276);
       END_STATE();
     case 295:
-      if (lookahead == 'o') ADVANCE(81);
+      if (lookahead == 'o') ADVANCE(309);
       END_STATE();
     case 296:
-      if (lookahead == 'o') ADVANCE(272);
+      if (lookahead == 'o') ADVANCE(281);
       END_STATE();
     case 297:
       if (lookahead == 'o') ADVANCE(323);
       END_STATE();
     case 298:
-      if (lookahead == 'o') ADVANCE(238);
+      if (lookahead == 'o') ADVANCE(82);
       END_STATE();
     case 299:
-      if (lookahead == 'o') ADVANCE(287);
+      if (lookahead == 'p') ADVANCE(243);
       END_STATE();
     case 300:
-      if (lookahead == 'o') ADVANCE(280);
+      if (lookahead == 'p') ADVANCE(149);
       END_STATE();
     case 301:
-      if (lookahead == 'o') ADVANCE(315);
+      if (lookahead == 'p') ADVANCE(97);
       END_STATE();
     case 302:
-      if (lookahead == 'o') ADVANCE(285);
+      if (lookahead == 'p') ADVANCE(178);
       END_STATE();
     case 303:
-      if (lookahead == 'o') ADVANCE(329);
+      if (lookahead == 'q') ADVANCE(406);
+      if (lookahead == 't') ADVANCE(252);
       END_STATE();
     case 304:
-      if (lookahead == 'o') ADVANCE(84);
+      if (lookahead == 'r') ADVANCE(411);
       END_STATE();
     case 305:
-      if (lookahead == 'p') ADVANCE(246);
+      if (lookahead == 'r') ADVANCE(466);
       END_STATE();
     case 306:
-      if (lookahead == 'p') ADVANCE(152);
+      if (lookahead == 'r') ADVANCE(488);
       END_STATE();
     case 307:
-      if (lookahead == 'p') ADVANCE(99);
+      if (lookahead == 'r') ADVANCE(460);
       END_STATE();
     case 308:
-      if (lookahead == 'p') ADVANCE(181);
+      if (lookahead == 'r') ADVANCE(562);
       END_STATE();
     case 309:
-      if (lookahead == 'q') ADVANCE(414);
-      if (lookahead == 't') ADVANCE(255);
+      if (lookahead == 'r') ADVANCE(458);
       END_STATE();
     case 310:
-      if (lookahead == 'r') ADVANCE(420);
+      if (lookahead == 'r') ADVANCE(492);
       END_STATE();
     case 311:
-      if (lookahead == 'r') ADVANCE(475);
+      if (lookahead == 'r') ADVANCE(564);
       END_STATE();
     case 312:
-      if (lookahead == 'r') ADVANCE(497);
+      if (lookahead == 'r') ADVANCE(314);
       END_STATE();
     case 313:
-      if (lookahead == 'r') ADVANCE(469);
+      if (lookahead == 'r') ADVANCE(184);
       END_STATE();
     case 314:
-      if (lookahead == 'r') ADVANCE(572);
+      if (lookahead == 'r') ADVANCE(70);
       END_STATE();
     case 315:
-      if (lookahead == 'r') ADVANCE(467);
+      if (lookahead == 'r') ADVANCE(405);
+      if (lookahead == 'y') ADVANCE(300);
       END_STATE();
     case 316:
-      if (lookahead == 'r') ADVANCE(501);
+      if (lookahead == 'r') ADVANCE(205);
       END_STATE();
     case 317:
-      if (lookahead == 'r') ADVANCE(574);
+      if (lookahead == 'r') ADVANCE(121);
       END_STATE();
     case 318:
-      if (lookahead == 'r') ADVANCE(320);
+      if (lookahead == 'r') ADVANCE(98);
       END_STATE();
     case 319:
-      if (lookahead == 'r') ADVANCE(187);
+      if (lookahead == 'r') ADVANCE(384);
       END_STATE();
     case 320:
-      if (lookahead == 'r') ADVANCE(71);
+      if (lookahead == 'r') ADVANCE(423);
       END_STATE();
     case 321:
-      if (lookahead == 'r') ADVANCE(413);
-      if (lookahead == 'y') ADVANCE(306);
+      if (lookahead == 'r') ADVANCE(206);
       END_STATE();
     case 322:
-      if (lookahead == 'r') ADVANCE(208);
+      if (lookahead == 'r') ADVANCE(152);
       END_STATE();
     case 323:
-      if (lookahead == 'r') ADVANCE(123);
+      if (lookahead == 'r') ADVANCE(371);
       END_STATE();
     case 324:
-      if (lookahead == 'r') ADVANCE(100);
-      END_STATE();
-    case 325:
-      if (lookahead == 'r') ADVANCE(392);
-      END_STATE();
-    case 326:
-      if (lookahead == 'r') ADVANCE(432);
-      END_STATE();
-    case 327:
-      if (lookahead == 'r') ADVANCE(209);
-      END_STATE();
-    case 328:
       if (lookahead == 'r') ADVANCE(155);
       END_STATE();
-    case 329:
-      if (lookahead == 'r') ADVANCE(378);
+    case 325:
+      if (lookahead == 'r') ADVANCE(75);
       END_STATE();
-    case 330:
-      if (lookahead == 'r') ADVANCE(158);
+    case 326:
+      if (lookahead == 'r') ADVANCE(213);
       END_STATE();
-    case 331:
+    case 327:
       if (lookahead == 'r') ADVANCE(76);
       END_STATE();
-    case 332:
-      if (lookahead == 'r') ADVANCE(218);
+    case 328:
+      if (lookahead == 'r') ADVANCE(78);
       END_STATE();
-    case 333:
-      if (lookahead == 'r') ADVANCE(77);
-      END_STATE();
-    case 334:
-      if (lookahead == 'r') ADVANCE(79);
-      END_STATE();
-    case 335:
+    case 329:
       if (lookahead == 'r') ADVANCE(80);
       END_STATE();
-    case 336:
-      if (lookahead == 'r') ADVANCE(214);
+    case 330:
+      if (lookahead == 'r') ADVANCE(212);
       END_STATE();
-    case 337:
+    case 331:
       if (lookahead == 'r') ADVANCE(83);
       END_STATE();
-    case 338:
-      if (lookahead == 'r') ADVANCE(216);
+    case 332:
+      if (lookahead == 'r') ADVANCE(214);
       END_STATE();
-    case 339:
-      if (lookahead == 'r') ADVANCE(85);
+    case 333:
+      if (lookahead == 'r') ADVANCE(84);
       END_STATE();
-    case 340:
-      if (lookahead == 'r') ADVANCE(219);
+    case 334:
+      if (lookahead == 'r') ADVANCE(217);
       END_STATE();
-    case 341:
+    case 335:
+      if (lookahead == 'r') ADVANCE(87);
+      END_STATE();
+    case 336:
       if (lookahead == 'r') ADVANCE(88);
       END_STATE();
-    case 342:
-      if (lookahead == 'r') ADVANCE(90);
+    case 337:
+      if (lookahead == 'r') ADVANCE(89);
       END_STATE();
-    case 343:
+    case 338:
       if (lookahead == 'r') ADVANCE(91);
       END_STATE();
-    case 344:
+    case 339:
+      if (lookahead == 'r') ADVANCE(92);
+      END_STATE();
+    case 340:
       if (lookahead == 'r') ADVANCE(93);
       END_STATE();
-    case 345:
+    case 341:
       if (lookahead == 'r') ADVANCE(94);
       END_STATE();
-    case 346:
+    case 342:
       if (lookahead == 'r') ADVANCE(95);
       END_STATE();
+    case 343:
+      if (lookahead == 'r') ADVANCE(325);
+      END_STATE();
+    case 344:
+      if (lookahead == 'r') ADVANCE(227);
+      END_STATE();
+    case 345:
+      if (lookahead == 'r') ADVANCE(327);
+      END_STATE();
+    case 346:
+      if (lookahead == 'r') ADVANCE(328);
+      END_STATE();
     case 347:
-      if (lookahead == 'r') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(329);
       END_STATE();
     case 348:
-      if (lookahead == 'r') ADVANCE(97);
-      END_STATE();
-    case 349:
       if (lookahead == 'r') ADVANCE(331);
       END_STATE();
-    case 350:
-      if (lookahead == 'r') ADVANCE(230);
-      END_STATE();
-    case 351:
+    case 349:
       if (lookahead == 'r') ADVANCE(333);
       END_STATE();
-    case 352:
-      if (lookahead == 'r') ADVANCE(334);
-      END_STATE();
-    case 353:
+    case 350:
       if (lookahead == 'r') ADVANCE(335);
       END_STATE();
-    case 354:
+    case 351:
+      if (lookahead == 'r') ADVANCE(336);
+      END_STATE();
+    case 352:
       if (lookahead == 'r') ADVANCE(337);
       END_STATE();
-    case 355:
+    case 353:
+      if (lookahead == 'r') ADVANCE(338);
+      END_STATE();
+    case 354:
       if (lookahead == 'r') ADVANCE(339);
+      END_STATE();
+    case 355:
+      if (lookahead == 'r') ADVANCE(340);
       END_STATE();
     case 356:
       if (lookahead == 'r') ADVANCE(341);
@@ -2977,220 +2967,220 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'r') ADVANCE(342);
       END_STATE();
     case 358:
-      if (lookahead == 'r') ADVANCE(343);
+      if (lookahead == 'r') ADVANCE(100);
       END_STATE();
     case 359:
-      if (lookahead == 'r') ADVANCE(344);
+      if (lookahead == 'r') ADVANCE(358);
       END_STATE();
     case 360:
-      if (lookahead == 'r') ADVANCE(345);
+      if (lookahead == 's') ADVANCE(447);
       END_STATE();
     case 361:
-      if (lookahead == 'r') ADVANCE(346);
+      if (lookahead == 's') ADVANCE(301);
       END_STATE();
     case 362:
-      if (lookahead == 'r') ADVANCE(347);
+      if (lookahead == 's') ADVANCE(156);
       END_STATE();
     case 363:
-      if (lookahead == 'r') ADVANCE(348);
+      if (lookahead == 's') ADVANCE(368);
       END_STATE();
     case 364:
-      if (lookahead == 'r') ADVANCE(102);
+      if (lookahead == 's') ADVANCE(137);
       END_STATE();
     case 365:
-      if (lookahead == 'r') ADVANCE(364);
+      if (lookahead == 's') ADVANCE(141);
       END_STATE();
     case 366:
-      if (lookahead == 's') ADVANCE(456);
+      if (lookahead == 's') ADVANCE(398);
       END_STATE();
     case 367:
-      if (lookahead == 's') ADVANCE(307);
-      END_STATE();
-    case 368:
-      if (lookahead == 's') ADVANCE(159);
-      END_STATE();
-    case 369:
-      if (lookahead == 's') ADVANCE(385);
-      END_STATE();
-    case 370:
-      if (lookahead == 's') ADVANCE(375);
-      END_STATE();
-    case 371:
-      if (lookahead == 's') ADVANCE(139);
-      END_STATE();
-    case 372:
-      if (lookahead == 's') ADVANCE(143);
-      END_STATE();
-    case 373:
-      if (lookahead == 's') ADVANCE(406);
-      END_STATE();
-    case 374:
       if (lookahead == 't') ADVANCE(24);
       END_STATE();
-    case 375:
-      if (lookahead == 't') ADVANCE(464);
+    case 368:
+      if (lookahead == 't') ADVANCE(455);
       END_STATE();
-    case 376:
-      if (lookahead == 't') ADVANCE(557);
-      END_STATE();
-    case 377:
-      if (lookahead == 't') ADVANCE(545);
-      END_STATE();
-    case 378:
-      if (lookahead == 't') ADVANCE(551);
-      END_STATE();
-    case 379:
+    case 369:
       if (lookahead == 't') ADVANCE(547);
       END_STATE();
-    case 380:
-      if (lookahead == 't') ADVANCE(533);
+    case 370:
+      if (lookahead == 't') ADVANCE(535);
       END_STATE();
-    case 381:
-      if (lookahead == 't') ADVANCE(477);
+    case 371:
+      if (lookahead == 't') ADVANCE(541);
       END_STATE();
-    case 382:
-      if (lookahead == 't') ADVANCE(225);
+    case 372:
+      if (lookahead == 't') ADVANCE(537);
       END_STATE();
-    case 383:
+    case 373:
+      if (lookahead == 't') ADVANCE(523);
+      END_STATE();
+    case 374:
+      if (lookahead == 't') ADVANCE(468);
+      END_STATE();
+    case 375:
+      if (lookahead == 't') ADVANCE(218);
+      END_STATE();
+    case 376:
       if (lookahead == 't') ADVANCE(23);
       END_STATE();
-    case 384:
+    case 377:
       if (lookahead == 't') ADVANCE(34);
       END_STATE();
+    case 378:
+      if (lookahead == 't') ADVANCE(68);
+      END_STATE();
+    case 379:
+      if (lookahead == 't') ADVANCE(179);
+      END_STATE();
+    case 380:
+      if (lookahead == 't') ADVANCE(416);
+      END_STATE();
+    case 381:
+      if (lookahead == 't') ADVANCE(316);
+      END_STATE();
+    case 382:
+      if (lookahead == 't') ADVANCE(135);
+      END_STATE();
+    case 383:
+      if (lookahead == 't') ADVANCE(418);
+      END_STATE();
+    case 384:
+      if (lookahead == 't') ADVANCE(208);
+      END_STATE();
     case 385:
-      if (lookahead == 't') ADVANCE(62);
+      if (lookahead == 't') ADVANCE(203);
       END_STATE();
     case 386:
-      if (lookahead == 't') ADVANCE(69);
+      if (lookahead == 't') ADVANCE(330);
       END_STATE();
     case 387:
-      if (lookahead == 't') ADVANCE(182);
+      if (lookahead == 't') ADVANCE(145);
       END_STATE();
     case 388:
-      if (lookahead == 't') ADVANCE(425);
+      if (lookahead == 't') ADVANCE(162);
       END_STATE();
     case 389:
-      if (lookahead == 't') ADVANCE(322);
+      if (lookahead == 't') ADVANCE(163);
       END_STATE();
     case 390:
-      if (lookahead == 't') ADVANCE(137);
+      if (lookahead == 't') ADVANCE(321);
       END_STATE();
     case 391:
-      if (lookahead == 't') ADVANCE(427);
+      if (lookahead == 't') ADVANCE(295);
       END_STATE();
     case 392:
-      if (lookahead == 't') ADVANCE(211);
+      if (lookahead == 't') ADVANCE(168);
       END_STATE();
     case 393:
-      if (lookahead == 't') ADVANCE(206);
+      if (lookahead == 't') ADVANCE(394);
       END_STATE();
     case 394:
-      if (lookahead == 't') ADVANCE(336);
+      if (lookahead == 't') ADVANCE(164);
       END_STATE();
     case 395:
-      if (lookahead == 't') ADVANCE(147);
-      END_STATE();
-    case 396:
-      if (lookahead == 't') ADVANCE(165);
-      END_STATE();
-    case 397:
-      if (lookahead == 't') ADVANCE(166);
-      END_STATE();
-    case 398:
-      if (lookahead == 't') ADVANCE(327);
-      END_STATE();
-    case 399:
-      if (lookahead == 't') ADVANCE(301);
-      END_STATE();
-    case 400:
-      if (lookahead == 't') ADVANCE(171);
-      END_STATE();
-    case 401:
-      if (lookahead == 't') ADVANCE(402);
-      END_STATE();
-    case 402:
       if (lookahead == 't') ADVANCE(167);
       END_STATE();
-    case 403:
-      if (lookahead == 't') ADVANCE(170);
+    case 396:
+      if (lookahead == 't') ADVANCE(225);
       END_STATE();
-    case 404:
-      if (lookahead == 't') ADVANCE(228);
+    case 397:
+      if (lookahead == 't') ADVANCE(332);
       END_STATE();
-    case 405:
-      if (lookahead == 't') ADVANCE(338);
+    case 398:
+      if (lookahead == 't') ADVANCE(344);
       END_STATE();
-    case 406:
-      if (lookahead == 't') ADVANCE(350);
+    case 399:
+      if (lookahead == 't') ADVANCE(334);
       END_STATE();
-    case 407:
-      if (lookahead == 't') ADVANCE(340);
-      END_STATE();
-    case 408:
+    case 400:
       if (lookahead == 't') ADVANCE(35);
       END_STATE();
+    case 401:
+      if (lookahead == 'u') ADVANCE(106);
+      END_STATE();
+    case 402:
+      if (lookahead == 'u') ADVANCE(253);
+      END_STATE();
+    case 403:
+      if (lookahead == 'u') ADVANCE(183);
+      END_STATE();
+    case 404:
+      if (lookahead == 'u') ADVANCE(221);
+      END_STATE();
+    case 405:
+      if (lookahead == 'u') ADVANCE(136);
+      END_STATE();
+    case 406:
+      if (lookahead == 'u') ADVANCE(170);
+      END_STATE();
+    case 407:
+      if (lookahead == 'u') ADVANCE(129);
+      END_STATE();
+    case 408:
+      if (lookahead == 'u') ADVANCE(114);
+      END_STATE();
     case 409:
-      if (lookahead == 'u') ADVANCE(108);
+      if (lookahead == 'u') ADVANCE(387);
       END_STATE();
     case 410:
-      if (lookahead == 'u') ADVANCE(257);
+      if (lookahead == 'u') ADVANCE(189);
       END_STATE();
     case 411:
-      if (lookahead == 'u') ADVANCE(186);
+      if (lookahead == 'v') ADVANCE(99);
       END_STATE();
     case 412:
-      if (lookahead == 'u') ADVANCE(223);
+      if (lookahead == 'w') ADVANCE(566);
       END_STATE();
     case 413:
-      if (lookahead == 'u') ADVANCE(138);
+      if (lookahead == 'x') ADVANCE(209);
       END_STATE();
     case 414:
-      if (lookahead == 'u') ADVANCE(173);
+      if (lookahead == 'y') ADVANCE(517);
       END_STATE();
     case 415:
-      if (lookahead == 'u') ADVANCE(150);
-      END_STATE();
-    case 416:
-      if (lookahead == 'u') ADVANCE(131);
-      END_STATE();
-    case 417:
-      if (lookahead == 'u') ADVANCE(116);
-      END_STATE();
-    case 418:
-      if (lookahead == 'u') ADVANCE(395);
-      END_STATE();
-    case 419:
-      if (lookahead == 'u') ADVANCE(192);
-      END_STATE();
-    case 420:
-      if (lookahead == 'v') ADVANCE(101);
-      END_STATE();
-    case 421:
-      if (lookahead == 'w') ADVANCE(576);
-      END_STATE();
-    case 422:
-      if (lookahead == 'x') ADVANCE(212);
-      END_STATE();
-    case 423:
-      if (lookahead == 'y') ADVANCE(527);
-      END_STATE();
-    case 424:
       if (lookahead == 'y') ADVANCE(51);
       END_STATE();
+    case 416:
+      if (lookahead == 'y') ADVANCE(514);
+      END_STATE();
+    case 417:
+      if (lookahead == 'y') ADVANCE(482);
+      END_STATE();
+    case 418:
+      if (lookahead == 'y') ADVANCE(513);
+      END_STATE();
+    case 419:
+      if (lookahead == 'y') ADVANCE(568);
+      END_STATE();
+    case 420:
+      if (lookahead == 'y') ADVANCE(570);
+      END_STATE();
+    case 421:
+      if (lookahead == 'y') ADVANCE(572);
+      END_STATE();
+    case 422:
+      if (lookahead == 'y') ADVANCE(574);
+      END_STATE();
+    case 423:
+      if (lookahead == 'y') ADVANCE(462);
+      END_STATE();
+    case 424:
+      if (lookahead == 'y') ADVANCE(527);
+      END_STATE();
     case 425:
-      if (lookahead == 'y') ADVANCE(524);
+      if (lookahead == 'y') ADVANCE(576);
       END_STATE();
     case 426:
-      if (lookahead == 'y') ADVANCE(491);
-      END_STATE();
-    case 427:
-      if (lookahead == 'y') ADVANCE(523);
-      END_STATE();
-    case 428:
       if (lookahead == 'y') ADVANCE(578);
       END_STATE();
+    case 427:
+      if (lookahead == 'y') ADVANCE(586);
+      END_STATE();
+    case 428:
+      if (lookahead == 'y') ADVANCE(588);
+      END_STATE();
     case 429:
-      if (lookahead == 'y') ADVANCE(580);
+      if (lookahead == 'y') ADVANCE(590);
       END_STATE();
     case 430:
       if (lookahead == 'y') ADVANCE(582);
@@ -3199,1685 +3189,1750 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'y') ADVANCE(584);
       END_STATE();
     case 432:
-      if (lookahead == 'y') ADVANCE(471);
+      if (lookahead == 'y') ADVANCE(529);
       END_STATE();
     case 433:
-      if (lookahead == 'y') ADVANCE(537);
+      if (lookahead == 'y') ADVANCE(580);
       END_STATE();
     case 434:
-      if (lookahead == 'y') ADVANCE(586);
+      if (lookahead == 'y') ADVANCE(266);
       END_STATE();
     case 435:
-      if (lookahead == 'y') ADVANCE(588);
-      END_STATE();
-    case 436:
-      if (lookahead == 'y') ADVANCE(596);
-      END_STATE();
-    case 437:
-      if (lookahead == 'y') ADVANCE(598);
-      END_STATE();
-    case 438:
-      if (lookahead == 'y') ADVANCE(600);
-      END_STATE();
-    case 439:
-      if (lookahead == 'y') ADVANCE(592);
-      END_STATE();
-    case 440:
-      if (lookahead == 'y') ADVANCE(594);
-      END_STATE();
-    case 441:
-      if (lookahead == 'y') ADVANCE(539);
-      END_STATE();
-    case 442:
-      if (lookahead == 'y') ADVANCE(590);
-      END_STATE();
-    case 443:
-      if (lookahead == 'y') ADVANCE(270);
-      END_STATE();
-    case 444:
       if (lookahead == 'y') ADVANCE(52);
       END_STATE();
-    case 445:
-      if (lookahead == 'z') ADVANCE(169);
+    case 436:
+      if (lookahead == 'z') ADVANCE(166);
       END_STATE();
-    case 446:
+    case 437:
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(448);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(608);
+          lookahead == '-') ADVANCE(439);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(598);
       END_STATE();
-    case 447:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(607);
+    case 438:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(597);
       END_STATE();
-    case 448:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(608);
+    case 439:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(598);
       END_STATE();
-    case 449:
+    case 440:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(606);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(596);
       END_STATE();
-    case 450:
+    case 441:
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 451:
-      if (eof) ADVANCE(452);
+    case 442:
+      if (eof) ADVANCE(443);
       ADVANCE_MAP(
         '/', 10,
-        'd', 790,
-        'e', 843,
-        'n', 649,
-        'p', 650,
-        't', 1007,
-        '-', 450,
-        '_', 450,
-        '\t', 1031,
-        '\n', 1031,
-        '\r', 1031,
-        ' ', 1031,
+        'd', 780,
+        'e', 833,
+        'n', 639,
+        'p', 640,
+        't', 997,
+        '-', 441,
+        '_', 441,
+        '\t', 1021,
+        '\n', 1021,
+        '\r', 1021,
+        ' ', 1021,
       );
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 452:
+    case 443:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 453:
+    case 444:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 454:
+    case 445:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 455:
+    case 446:
       ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
-    case 456:
+    case 447:
       ACCEPT_TOKEN(anon_sym_includes);
+      END_STATE();
+    case 448:
+      ACCEPT_TOKEN(anon_sym_includes);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 449:
+      ACCEPT_TOKEN(anon_sym_async);
+      END_STATE();
+    case 450:
+      ACCEPT_TOKEN(anon_sym_async);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 451:
+      ACCEPT_TOKEN(anon_sym_attribute);
+      END_STATE();
+    case 452:
+      ACCEPT_TOKEN(anon_sym_attribute);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 453:
+      ACCEPT_TOKEN(anon_sym_callback);
+      END_STATE();
+    case 454:
+      ACCEPT_TOKEN(anon_sym_callback);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 455:
+      ACCEPT_TOKEN(anon_sym_const);
+      if (lookahead == 'r') ADVANCE(408);
+      END_STATE();
+    case 456:
+      ACCEPT_TOKEN(anon_sym_const);
+      if (lookahead == 'r') ADVANCE(991);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 457:
-      ACCEPT_TOKEN(anon_sym_includes);
+      ACCEPT_TOKEN(anon_sym_const);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 458:
-      ACCEPT_TOKEN(anon_sym_async);
+      ACCEPT_TOKEN(anon_sym_constructor);
       END_STATE();
     case 459:
-      ACCEPT_TOKEN(anon_sym_async);
+      ACCEPT_TOKEN(anon_sym_constructor);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 460:
-      ACCEPT_TOKEN(anon_sym_attribute);
+      ACCEPT_TOKEN(anon_sym_deleter);
       END_STATE();
     case 461:
-      ACCEPT_TOKEN(anon_sym_attribute);
+      ACCEPT_TOKEN(anon_sym_deleter);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 462:
-      ACCEPT_TOKEN(anon_sym_callback);
+      ACCEPT_TOKEN(anon_sym_dictionary);
       END_STATE();
     case 463:
-      ACCEPT_TOKEN(anon_sym_callback);
+      ACCEPT_TOKEN(anon_sym_dictionary);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 464:
-      ACCEPT_TOKEN(anon_sym_const);
-      if (lookahead == 'r') ADVANCE(417);
+      ACCEPT_TOKEN(anon_sym_enum);
       END_STATE();
     case 465:
-      ACCEPT_TOKEN(anon_sym_const);
-      if (lookahead == 'r') ADVANCE(1001);
+      ACCEPT_TOKEN(anon_sym_enum);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 466:
-      ACCEPT_TOKEN(anon_sym_const);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_getter);
       END_STATE();
     case 467:
-      ACCEPT_TOKEN(anon_sym_constructor);
+      ACCEPT_TOKEN(anon_sym_getter);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 468:
-      ACCEPT_TOKEN(anon_sym_constructor);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_inherit);
       END_STATE();
     case 469:
-      ACCEPT_TOKEN(anon_sym_deleter);
+      ACCEPT_TOKEN(anon_sym_inherit);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 470:
-      ACCEPT_TOKEN(anon_sym_deleter);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_interface);
       END_STATE();
     case 471:
-      ACCEPT_TOKEN(anon_sym_dictionary);
+      ACCEPT_TOKEN(anon_sym_interface);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 472:
-      ACCEPT_TOKEN(anon_sym_dictionary);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_iterable);
       END_STATE();
     case 473:
-      ACCEPT_TOKEN(anon_sym_enum);
+      ACCEPT_TOKEN(anon_sym_iterable);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 474:
-      ACCEPT_TOKEN(anon_sym_enum);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_maplike);
       END_STATE();
     case 475:
-      ACCEPT_TOKEN(anon_sym_getter);
+      ACCEPT_TOKEN(anon_sym_maplike);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 476:
-      ACCEPT_TOKEN(anon_sym_getter);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_mixin);
       END_STATE();
     case 477:
-      ACCEPT_TOKEN(anon_sym_inherit);
+      ACCEPT_TOKEN(anon_sym_mixin);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 478:
-      ACCEPT_TOKEN(anon_sym_inherit);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_namespace);
       END_STATE();
     case 479:
-      ACCEPT_TOKEN(anon_sym_interface);
+      ACCEPT_TOKEN(anon_sym_namespace);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 480:
-      ACCEPT_TOKEN(anon_sym_interface);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_partial);
       END_STATE();
     case 481:
-      ACCEPT_TOKEN(anon_sym_iterable);
+      ACCEPT_TOKEN(anon_sym_partial);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 482:
-      ACCEPT_TOKEN(anon_sym_iterable);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_readonly);
       END_STATE();
     case 483:
-      ACCEPT_TOKEN(anon_sym_maplike);
+      ACCEPT_TOKEN(anon_sym_readonly);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 484:
-      ACCEPT_TOKEN(anon_sym_maplike);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_required);
       END_STATE();
     case 485:
-      ACCEPT_TOKEN(anon_sym_mixin);
+      ACCEPT_TOKEN(anon_sym_required);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 486:
-      ACCEPT_TOKEN(anon_sym_mixin);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_setlike);
       END_STATE();
     case 487:
-      ACCEPT_TOKEN(anon_sym_namespace);
+      ACCEPT_TOKEN(anon_sym_setlike);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 488:
-      ACCEPT_TOKEN(anon_sym_namespace);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_setter);
       END_STATE();
     case 489:
-      ACCEPT_TOKEN(anon_sym_partial);
+      ACCEPT_TOKEN(anon_sym_setter);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 490:
-      ACCEPT_TOKEN(anon_sym_partial);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_static);
       END_STATE();
     case 491:
-      ACCEPT_TOKEN(anon_sym_readonly);
+      ACCEPT_TOKEN(anon_sym_static);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 492:
-      ACCEPT_TOKEN(anon_sym_readonly);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_stringifier);
       END_STATE();
     case 493:
-      ACCEPT_TOKEN(anon_sym_required);
+      ACCEPT_TOKEN(anon_sym_stringifier);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 494:
-      ACCEPT_TOKEN(anon_sym_required);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_typedef);
       END_STATE();
     case 495:
-      ACCEPT_TOKEN(anon_sym_setlike);
+      ACCEPT_TOKEN(anon_sym_typedef);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 496:
-      ACCEPT_TOKEN(anon_sym_setlike);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+      ACCEPT_TOKEN(anon_sym_unrestricted);
       END_STATE();
     case 497:
-      ACCEPT_TOKEN(anon_sym_setter);
+      ACCEPT_TOKEN(anon_sym_unrestricted);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 498:
-      ACCEPT_TOKEN(anon_sym_setter);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 499:
-      ACCEPT_TOKEN(anon_sym_static);
-      END_STATE();
-    case 500:
-      ACCEPT_TOKEN(anon_sym_static);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 501:
-      ACCEPT_TOKEN(anon_sym_stringifier);
-      END_STATE();
-    case 502:
-      ACCEPT_TOKEN(anon_sym_stringifier);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 503:
-      ACCEPT_TOKEN(anon_sym_typedef);
-      END_STATE();
-    case 504:
-      ACCEPT_TOKEN(anon_sym_typedef);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 505:
-      ACCEPT_TOKEN(anon_sym_unrestricted);
-      END_STATE();
-    case 506:
-      ACCEPT_TOKEN(anon_sym_unrestricted);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 507:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 508:
+    case 499:
       ACCEPT_TOKEN(anon_sym_optional);
       END_STATE();
-    case 509:
+    case 500:
       ACCEPT_TOKEN(anon_sym_optional);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 510:
+    case 501:
       ACCEPT_TOKEN(sym_ellipsis);
       END_STATE();
-    case 511:
+    case 502:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 512:
+    case 503:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 513:
+    case 504:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 514:
+    case 505:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 515:
-      ACCEPT_TOKEN(anon_sym_ConstValue);
-      END_STATE();
-    case 516:
+    case 506:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
-    case 517:
+    case 507:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 518:
+    case 508:
       ACCEPT_TOKEN(anon_sym_null);
       END_STATE();
-    case 519:
+    case 509:
       ACCEPT_TOKEN(anon_sym_undefined);
       END_STATE();
-    case 520:
+    case 510:
       ACCEPT_TOKEN(anon_sym_undefined);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 521:
+    case 511:
       ACCEPT_TOKEN(anon_sym_true);
       END_STATE();
-    case 522:
+    case 512:
       ACCEPT_TOKEN(anon_sym_false);
       END_STATE();
-    case 523:
+    case 513:
       ACCEPT_TOKEN(anon_sym_DASHInfinity);
       END_STATE();
-    case 524:
+    case 514:
       ACCEPT_TOKEN(anon_sym_Infinity);
       END_STATE();
-    case 525:
+    case 515:
       ACCEPT_TOKEN(anon_sym_NaN);
       END_STATE();
-    case 526:
+    case 516:
       ACCEPT_TOKEN(anon_sym_QMARK);
       END_STATE();
-    case 527:
+    case 517:
       ACCEPT_TOKEN(anon_sym_any);
       END_STATE();
-    case 528:
+    case 518:
       ACCEPT_TOKEN(anon_sym_any);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 529:
+    case 519:
       ACCEPT_TOKEN(anon_sym_or);
       END_STATE();
-    case 530:
+    case 520:
       ACCEPT_TOKEN(anon_sym_sequence);
       END_STATE();
-    case 531:
+    case 521:
       ACCEPT_TOKEN(anon_sym_sequence);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 532:
+    case 522:
       ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
-    case 533:
+    case 523:
       ACCEPT_TOKEN(anon_sym_object);
+      END_STATE();
+    case 524:
+      ACCEPT_TOKEN(anon_sym_object);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 525:
+      ACCEPT_TOKEN(anon_sym_symbol);
+      END_STATE();
+    case 526:
+      ACCEPT_TOKEN(anon_sym_symbol);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 527:
+      ACCEPT_TOKEN(anon_sym_FrozenArray);
+      END_STATE();
+    case 528:
+      ACCEPT_TOKEN(anon_sym_FrozenArray);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 529:
+      ACCEPT_TOKEN(anon_sym_ObservableArray);
+      END_STATE();
+    case 530:
+      ACCEPT_TOKEN(anon_sym_ObservableArray);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 531:
+      ACCEPT_TOKEN(anon_sym_boolean);
+      END_STATE();
+    case 532:
+      ACCEPT_TOKEN(anon_sym_boolean);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 533:
+      ACCEPT_TOKEN(anon_sym_byte);
       END_STATE();
     case 534:
-      ACCEPT_TOKEN(anon_sym_object);
+      ACCEPT_TOKEN(anon_sym_byte);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 535:
-      ACCEPT_TOKEN(anon_sym_symbol);
+      ACCEPT_TOKEN(anon_sym_octet);
       END_STATE();
     case 536:
-      ACCEPT_TOKEN(anon_sym_symbol);
+      ACCEPT_TOKEN(anon_sym_octet);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 537:
-      ACCEPT_TOKEN(anon_sym_FrozenArray);
+      ACCEPT_TOKEN(anon_sym_bigint);
       END_STATE();
     case 538:
-      ACCEPT_TOKEN(anon_sym_FrozenArray);
+      ACCEPT_TOKEN(anon_sym_bigint);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 539:
-      ACCEPT_TOKEN(anon_sym_ObservableArray);
+      ACCEPT_TOKEN(anon_sym_unsigned);
       END_STATE();
     case 540:
-      ACCEPT_TOKEN(anon_sym_ObservableArray);
+      ACCEPT_TOKEN(anon_sym_unsigned);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 541:
-      ACCEPT_TOKEN(anon_sym_boolean);
+      ACCEPT_TOKEN(anon_sym_short);
       END_STATE();
     case 542:
-      ACCEPT_TOKEN(anon_sym_boolean);
+      ACCEPT_TOKEN(anon_sym_short);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 543:
-      ACCEPT_TOKEN(anon_sym_byte);
+      ACCEPT_TOKEN(anon_sym_long);
       END_STATE();
     case 544:
-      ACCEPT_TOKEN(anon_sym_byte);
+      ACCEPT_TOKEN(anon_sym_long);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 545:
-      ACCEPT_TOKEN(anon_sym_octet);
+      ACCEPT_TOKEN(anon_sym_restricted);
       END_STATE();
     case 546:
-      ACCEPT_TOKEN(anon_sym_octet);
+      ACCEPT_TOKEN(anon_sym_restricted);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 547:
-      ACCEPT_TOKEN(anon_sym_bigint);
+      ACCEPT_TOKEN(anon_sym_float);
       END_STATE();
     case 548:
-      ACCEPT_TOKEN(anon_sym_bigint);
+      ACCEPT_TOKEN(anon_sym_float);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 549:
-      ACCEPT_TOKEN(anon_sym_unsigned);
+      ACCEPT_TOKEN(anon_sym_double);
       END_STATE();
     case 550:
-      ACCEPT_TOKEN(anon_sym_unsigned);
+      ACCEPT_TOKEN(anon_sym_double);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 551:
-      ACCEPT_TOKEN(anon_sym_short);
+      ACCEPT_TOKEN(anon_sym_ByteString);
       END_STATE();
     case 552:
-      ACCEPT_TOKEN(anon_sym_short);
+      ACCEPT_TOKEN(anon_sym_ByteString);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 553:
-      ACCEPT_TOKEN(anon_sym_long);
+      ACCEPT_TOKEN(anon_sym_DOMString);
       END_STATE();
     case 554:
-      ACCEPT_TOKEN(anon_sym_long);
+      ACCEPT_TOKEN(anon_sym_DOMString);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 555:
-      ACCEPT_TOKEN(anon_sym_restricted);
+      ACCEPT_TOKEN(anon_sym_USVString);
       END_STATE();
     case 556:
-      ACCEPT_TOKEN(anon_sym_restricted);
+      ACCEPT_TOKEN(anon_sym_USVString);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 557:
-      ACCEPT_TOKEN(anon_sym_float);
+      ACCEPT_TOKEN(anon_sym_promise);
       END_STATE();
     case 558:
-      ACCEPT_TOKEN(anon_sym_float);
+      ACCEPT_TOKEN(anon_sym_promise);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 559:
-      ACCEPT_TOKEN(anon_sym_double);
-      END_STATE();
-    case 560:
-      ACCEPT_TOKEN(anon_sym_double);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 561:
-      ACCEPT_TOKEN(anon_sym_ByteString);
-      END_STATE();
-    case 562:
-      ACCEPT_TOKEN(anon_sym_ByteString);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 563:
-      ACCEPT_TOKEN(anon_sym_DOMString);
-      END_STATE();
-    case 564:
-      ACCEPT_TOKEN(anon_sym_DOMString);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 565:
-      ACCEPT_TOKEN(anon_sym_USVString);
-      END_STATE();
-    case 566:
-      ACCEPT_TOKEN(anon_sym_USVString);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 567:
-      ACCEPT_TOKEN(anon_sym_promise);
-      END_STATE();
-    case 568:
-      ACCEPT_TOKEN(anon_sym_promise);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 569:
       ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
-    case 570:
+    case 560:
       ACCEPT_TOKEN(anon_sym_record);
+      END_STATE();
+    case 561:
+      ACCEPT_TOKEN(anon_sym_record);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 562:
+      ACCEPT_TOKEN(anon_sym_ArrayBuffer);
+      END_STATE();
+    case 563:
+      ACCEPT_TOKEN(anon_sym_ArrayBuffer);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 564:
+      ACCEPT_TOKEN(anon_sym_SharedArrayBuffer);
+      END_STATE();
+    case 565:
+      ACCEPT_TOKEN(anon_sym_SharedArrayBuffer);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 566:
+      ACCEPT_TOKEN(anon_sym_DataView);
+      END_STATE();
+    case 567:
+      ACCEPT_TOKEN(anon_sym_DataView);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 568:
+      ACCEPT_TOKEN(anon_sym_Int8Array);
+      END_STATE();
+    case 569:
+      ACCEPT_TOKEN(anon_sym_Int8Array);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 570:
+      ACCEPT_TOKEN(anon_sym_Int16Array);
       END_STATE();
     case 571:
-      ACCEPT_TOKEN(anon_sym_record);
+      ACCEPT_TOKEN(anon_sym_Int16Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 572:
-      ACCEPT_TOKEN(anon_sym_ArrayBuffer);
+      ACCEPT_TOKEN(anon_sym_Int32Array);
       END_STATE();
     case 573:
-      ACCEPT_TOKEN(anon_sym_ArrayBuffer);
+      ACCEPT_TOKEN(anon_sym_Int32Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 574:
-      ACCEPT_TOKEN(anon_sym_SharedArrayBuffer);
+      ACCEPT_TOKEN(anon_sym_Uint8Array);
       END_STATE();
     case 575:
-      ACCEPT_TOKEN(anon_sym_SharedArrayBuffer);
+      ACCEPT_TOKEN(anon_sym_Uint8Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 576:
-      ACCEPT_TOKEN(anon_sym_DataView);
+      ACCEPT_TOKEN(anon_sym_Uint16Array);
       END_STATE();
     case 577:
-      ACCEPT_TOKEN(anon_sym_DataView);
+      ACCEPT_TOKEN(anon_sym_Uint16Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 578:
-      ACCEPT_TOKEN(anon_sym_Int8Array);
+      ACCEPT_TOKEN(anon_sym_Uint32Array);
       END_STATE();
     case 579:
-      ACCEPT_TOKEN(anon_sym_Int8Array);
+      ACCEPT_TOKEN(anon_sym_Uint32Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 580:
-      ACCEPT_TOKEN(anon_sym_Int16Array);
+      ACCEPT_TOKEN(anon_sym_Uint8ClampedArray);
       END_STATE();
     case 581:
-      ACCEPT_TOKEN(anon_sym_Int16Array);
+      ACCEPT_TOKEN(anon_sym_Uint8ClampedArray);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 582:
-      ACCEPT_TOKEN(anon_sym_Int32Array);
+      ACCEPT_TOKEN(anon_sym_BigInt64Array);
       END_STATE();
     case 583:
-      ACCEPT_TOKEN(anon_sym_Int32Array);
+      ACCEPT_TOKEN(anon_sym_BigInt64Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 584:
-      ACCEPT_TOKEN(anon_sym_Uint8Array);
+      ACCEPT_TOKEN(anon_sym_BigUint64Array);
       END_STATE();
     case 585:
-      ACCEPT_TOKEN(anon_sym_Uint8Array);
+      ACCEPT_TOKEN(anon_sym_BigUint64Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 586:
-      ACCEPT_TOKEN(anon_sym_Uint16Array);
+      ACCEPT_TOKEN(anon_sym_Float16Array);
       END_STATE();
     case 587:
-      ACCEPT_TOKEN(anon_sym_Uint16Array);
+      ACCEPT_TOKEN(anon_sym_Float16Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 588:
-      ACCEPT_TOKEN(anon_sym_Uint32Array);
+      ACCEPT_TOKEN(anon_sym_Float32Array);
       END_STATE();
     case 589:
-      ACCEPT_TOKEN(anon_sym_Uint32Array);
+      ACCEPT_TOKEN(anon_sym_Float32Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 590:
-      ACCEPT_TOKEN(anon_sym_Uint8ClampedArray);
+      ACCEPT_TOKEN(anon_sym_Float64Array);
       END_STATE();
     case 591:
-      ACCEPT_TOKEN(anon_sym_Uint8ClampedArray);
+      ACCEPT_TOKEN(anon_sym_Float64Array);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 592:
-      ACCEPT_TOKEN(anon_sym_BigInt64Array);
-      END_STATE();
-    case 593:
-      ACCEPT_TOKEN(anon_sym_BigInt64Array);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 594:
-      ACCEPT_TOKEN(anon_sym_BigUint64Array);
-      END_STATE();
-    case 595:
-      ACCEPT_TOKEN(anon_sym_BigUint64Array);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 596:
-      ACCEPT_TOKEN(anon_sym_Float16Array);
-      END_STATE();
-    case 597:
-      ACCEPT_TOKEN(anon_sym_Float16Array);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 598:
-      ACCEPT_TOKEN(anon_sym_Float32Array);
-      END_STATE();
-    case 599:
-      ACCEPT_TOKEN(anon_sym_Float32Array);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 600:
-      ACCEPT_TOKEN(anon_sym_Float64Array);
-      END_STATE();
-    case 601:
-      ACCEPT_TOKEN(anon_sym_Float64Array);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 602:
       ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
-    case 603:
+    case 593:
       ACCEPT_TOKEN(sym__integer);
-      if (lookahead == '.') ADVANCE(607);
+      if (lookahead == '.') ADVANCE(597);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(446);
+          lookahead == 'e') ADVANCE(437);
       if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(449);
+          lookahead == 'x') ADVANCE(440);
       if (lookahead == '8' ||
           lookahead == '9') ADVANCE(16);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(604);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(594);
       END_STATE();
-    case 604:
+    case 594:
       ACCEPT_TOKEN(sym__integer);
-      if (lookahead == '.') ADVANCE(607);
+      if (lookahead == '.') ADVANCE(597);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(446);
+          lookahead == 'e') ADVANCE(437);
       if (lookahead == '8' ||
           lookahead == '9') ADVANCE(16);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(604);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(594);
       END_STATE();
-    case 605:
+    case 595:
       ACCEPT_TOKEN(sym__integer);
-      if (lookahead == '.') ADVANCE(607);
+      if (lookahead == '.') ADVANCE(597);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(446);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(605);
+          lookahead == 'e') ADVANCE(437);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(595);
       END_STATE();
-    case 606:
+    case 596:
       ACCEPT_TOKEN(sym__integer);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(606);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(596);
       END_STATE();
-    case 607:
+    case 597:
       ACCEPT_TOKEN(sym__decimal);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(446);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(607);
+          lookahead == 'e') ADVANCE(437);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(597);
+      END_STATE();
+    case 598:
+      ACCEPT_TOKEN(sym__decimal);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(598);
+      END_STATE();
+    case 599:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '1') ADVANCE(608);
+      if (lookahead == '3') ADVANCE(602);
+      if (lookahead == '8') ADVANCE(613);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 600:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '1') ADVANCE(609);
+      if (lookahead == '3') ADVANCE(603);
+      if (lookahead == '8') ADVANCE(616);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 601:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '1') ADVANCE(610);
+      if (lookahead == '3') ADVANCE(604);
+      if (lookahead == '6') ADVANCE(605);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 602:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(615);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 603:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(619);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 604:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '2') ADVANCE(621);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 605:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(622);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 606:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(623);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 607:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '4') ADVANCE(624);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 608:
-      ACCEPT_TOKEN(sym__decimal);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(608);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '6') ADVANCE(614);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 609:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(618);
-      if (lookahead == '3') ADVANCE(612);
-      if (lookahead == '8') ADVANCE(623);
+      if (lookahead == '6') ADVANCE(618);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 610:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(619);
-      if (lookahead == '3') ADVANCE(613);
-      if (lookahead == '8') ADVANCE(626);
+      if (lookahead == '6') ADVANCE(620);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 611:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(620);
-      if (lookahead == '3') ADVANCE(614);
-      if (lookahead == '6') ADVANCE(615);
+      if (lookahead == '6') ADVANCE(606);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 612:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(625);
+      if (lookahead == '6') ADVANCE(607);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 613:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(629);
+      if (lookahead == 'A') ADVANCE(917);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 614:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(631);
+      if (lookahead == 'A') ADVANCE(919);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 615:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(632);
+      if (lookahead == 'A') ADVANCE(921);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 616:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(633);
+      if (lookahead == 'A') ADVANCE(923);
+      if (lookahead == 'C') ADVANCE(825);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 617:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(634);
+      if (lookahead == 'A') ADVANCE(924);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 618:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(624);
+      if (lookahead == 'A') ADVANCE(925);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 619:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(628);
+      if (lookahead == 'A') ADVANCE(926);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 620:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(630);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 621:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(616);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 622:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(617);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 623:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'A') ADVANCE(927);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 624:
+    case 621:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'A') ADVANCE(928);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 622:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'A') ADVANCE(929);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 625:
+    case 623:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'A') ADVANCE(930);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 624:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'A') ADVANCE(931);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 625:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'A') ADVANCE(932);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 626:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'A') ADVANCE(933);
-      if (lookahead == 'C') ADVANCE(835);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 627:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(934);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 628:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(935);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 629:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(936);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 630:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(937);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 631:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'A') ADVANCE(938);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 628:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'B') ADVANCE(987);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 629:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'B') ADVANCE(993);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 630:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'I') ADVANCE(850);
+      if (lookahead == 'U') ADVANCE(806);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 631:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'M') ADVANCE(634);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 632:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(939);
+      if (lookahead == 'O') ADVANCE(631);
+      if (lookahead == 'a') ADVANCE(966);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 633:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(940);
+      if (lookahead == 'S') ADVANCE(638);
+      if (lookahead == 'i') ADVANCE(844);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 634:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(941);
+      if (lookahead == 'S') ADVANCE(969);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 635:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(942);
+      if (lookahead == 'S') ADVANCE(981);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 636:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(943);
+      if (lookahead == 'S') ADVANCE(982);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 637:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'A') ADVANCE(948);
+      if (lookahead == 'V') ADVANCE(794);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 638:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'B') ADVANCE(997);
+      if (lookahead == 'V') ADVANCE(635);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 639:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'B') ADVANCE(1003);
+      if (lookahead == 'a') ADVANCE(828);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 640:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'I') ADVANCE(860);
-      if (lookahead == 'U') ADVANCE(816);
+      if (lookahead == 'a') ADVANCE(915);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 641:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'M') ADVANCE(644);
+      if (lookahead == 'a') ADVANCE(811);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 642:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'O') ADVANCE(641);
-      if (lookahead == 'a') ADVANCE(976);
+      if (lookahead == 'a') ADVANCE(688);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 643:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'S') ADVANCE(648);
-      if (lookahead == 'i') ADVANCE(854);
+      if (lookahead == 'a') ADVANCE(890);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 644:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'S') ADVANCE(979);
+      if (lookahead == 'a') ADVANCE(637);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 645:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'S') ADVANCE(991);
+      if (lookahead == 'a') ADVANCE(879);
+      if (lookahead == 'i') ADVANCE(996);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 646:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'S') ADVANCE(992);
+      if (lookahead == 'a') ADVANCE(1000);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 647:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'V') ADVANCE(804);
+      if (lookahead == 'a') ADVANCE(687);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 648:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'V') ADVANCE(645);
+      if (lookahead == 'a') ADVANCE(832);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 649:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(838);
+      if (lookahead == 'a') ADVANCE(1001);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 650:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(925);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 651:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(821);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 652:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(698);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 653:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(900);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 651:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(813);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 652:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1002);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 653:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(951);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 654:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(647);
+      if (lookahead == 'a') ADVANCE(817);
+      if (lookahead == 'o') ADVANCE(859);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 655:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(889);
-      if (lookahead == 'i') ADVANCE(1006);
+      if (lookahead == 'a') ADVANCE(1003);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 656:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(952);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 657:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(709);
+      if (lookahead == 'q') ADVANCE(988);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 658:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1004);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 659:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(835);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 660:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1005);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 661:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1006);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 662:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1007);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 663:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1008);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 664:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(1009);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 665:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(1010);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 657:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(697);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 658:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(842);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 659:
+    case 666:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(1011);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 660:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(910);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 661:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(823);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 662:
+    case 667:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(1012);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 663:
+    case 668:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(961);
+      if (lookahead == 'a') ADVANCE(978);
+      if (lookahead == 'r') ADVANCE(793);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 664:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(827);
-      if (lookahead == 'o') ADVANCE(869);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 665:
+    case 669:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(1013);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 666:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(962);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 667:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(719);
-      if (lookahead == 'q') ADVANCE(998);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 668:
+    case 670:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(1014);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 669:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(845);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 670:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1015);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 671:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1016);
+      if (lookahead == 'a') ADVANCE(696);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 672:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(682);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 673:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(683);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 674:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'a') ADVANCE(1017);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 673:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1018);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 674:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1019);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 675:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1020);
+      if (lookahead == 'b') ADVANCE(807);
+      if (lookahead == 'c') ADVANCE(970);
+      if (lookahead == 'p') ADVANCE(980);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 676:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1021);
+      if (lookahead == 'b') ADVANCE(807);
+      if (lookahead == 'c') ADVANCE(970);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 677:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1022);
+      if (lookahead == 'b') ADVANCE(945);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 678:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(988);
-      if (lookahead == 'r') ADVANCE(803);
+      if (lookahead == 'b') ADVANCE(992);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 679:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1023);
+      if (lookahead == 'b') ADVANCE(867);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 680:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1024);
+      if (lookahead == 'b') ADVANCE(647);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 681:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(706);
+      if (lookahead == 'b') ADVANCE(820);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 682:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(692);
+      if (lookahead == 'b') ADVANCE(822);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 683:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(693);
+      if (lookahead == 'b') ADVANCE(824);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 684:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(1027);
+      if (lookahead == 'c') ADVANCE(961);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 685:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(817);
-      if (lookahead == 'c') ADVANCE(980);
-      if (lookahead == 'p') ADVANCE(990);
+      if (lookahead == 'c') ADVANCE(450);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 686:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(817);
-      if (lookahead == 'c') ADVANCE(980);
+      if (lookahead == 'c') ADVANCE(491);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 687:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(955);
+      if (lookahead == 'c') ADVANCE(808);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 688:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(1002);
+      if (lookahead == 'c') ADVANCE(715);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 689:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(877);
+      if (lookahead == 'c') ADVANCE(869);
+      if (lookahead == 'q') ADVANCE(988);
+      if (lookahead == 's') ADVANCE(968);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 690:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(657);
+      if (lookahead == 'c') ADVANCE(869);
+      if (lookahead == 's') ADVANCE(968);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 691:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(830);
+      if (lookahead == 'c') ADVANCE(816);
+      if (lookahead == 'h') ADVANCE(745);
+      if (lookahead == 't') ADVANCE(747);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 692:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(832);
+      if (lookahead == 'c') ADVANCE(816);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 693:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'b') ADVANCE(834);
+      if (lookahead == 'c') ADVANCE(956);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 694:
       ACCEPT_TOKEN(sym_identifier);
@@ -4886,1995 +4941,1990 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 695:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(459);
+      if (lookahead == 'c') ADVANCE(722);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 696:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(500);
+      if (lookahead == 'c') ADVANCE(729);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 697:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(818);
+      if (lookahead == 'c') ADVANCE(970);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 698:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(725);
+      if (lookahead == 'c') ADVANCE(973);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 699:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(879);
-      if (lookahead == 'q') ADVANCE(998);
-      if (lookahead == 's') ADVANCE(978);
+      if (lookahead == 'c') ADVANCE(977);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 700:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(879);
-      if (lookahead == 's') ADVANCE(978);
+      if (lookahead == 'd') ADVANCE(561);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 701:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(826);
-      if (lookahead == 'h') ADVANCE(755);
-      if (lookahead == 't') ADVANCE(757);
+      if (lookahead == 'd') ADVANCE(485);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 702:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(826);
+      if (lookahead == 'd') ADVANCE(540);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 703:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(966);
+      if (lookahead == 'd') ADVANCE(510);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 704:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(981);
+      if (lookahead == 'd') ADVANCE(546);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 705:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(732);
+      if (lookahead == 'd') ADVANCE(497);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 706:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(739);
+      if (lookahead == 'd') ADVANCE(714);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 707:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(980);
+      if (lookahead == 'd') ADVANCE(731);
+      if (lookahead == 's') ADVANCE(787);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 708:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(983);
+      if (lookahead == 'd') ADVANCE(733);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 709:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'c') ADVANCE(987);
+      if (lookahead == 'd') ADVANCE(873);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 710:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(571);
+      if (lookahead == 'd') ADVANCE(627);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 711:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(494);
+      if (lookahead == 'd') ADVANCE(626);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 712:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(550);
+      if (lookahead == 'e') ADVANCE(940);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 713:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(520);
+      if (lookahead == 'e') ADVANCE(706);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 714:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(556);
+      if (lookahead == 'e') ADVANCE(762);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 715:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(506);
+      if (lookahead == 'e') ADVANCE(479);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 716:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(724);
+      if (lookahead == 'e') ADVANCE(689);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 717:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(741);
-      if (lookahead == 's') ADVANCE(797);
+      if (lookahead == 'e') ADVANCE(881);
+      if (lookahead == 'h') ADVANCE(875);
+      if (lookahead == 'y') ADVANCE(830);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 718:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(743);
+      if (lookahead == 'e') ADVANCE(534);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 719:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(883);
+      if (lookahead == 'e') ADVANCE(550);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 720:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(637);
+      if (lookahead == 'e') ADVANCE(995);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 721:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(636);
+      if (lookahead == 'e') ADVANCE(558);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 722:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(950);
+      if (lookahead == 'e') ADVANCE(521);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 723:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(716);
+      if (lookahead == 'e') ADVANCE(690);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 724:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(772);
+      if (lookahead == 'e') ADVANCE(657);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 725:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(488);
+      if (lookahead == 'e') ADVANCE(475);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 726:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(699);
+      if (lookahead == 'e') ADVANCE(487);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 727:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(891);
-      if (lookahead == 'h') ADVANCE(885);
-      if (lookahead == 'y') ADVANCE(840);
+      if (lookahead == 'e') ADVANCE(473);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 728:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(544);
+      if (lookahead == 'e') ADVANCE(452);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 729:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(560);
+      if (lookahead == 'e') ADVANCE(471);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 730:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(1005);
+      if (lookahead == 'e') ADVANCE(710);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 731:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(568);
+      if (lookahead == 'e') ADVANCE(764);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 732:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(531);
+      if (lookahead == 'e') ADVANCE(701);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 733:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(700);
+      if (lookahead == 'e') ADVANCE(939);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 734:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(667);
+      if (lookahead == 'e') ADVANCE(702);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 735:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(484);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 736:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(496);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 737:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(482);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 738:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(461);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 739:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(480);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 740:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(720);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 741:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(774);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 742:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(711);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 743:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(949);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 744:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(712);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 745:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(713);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 746:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(870);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 747:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(892);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 748:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(714);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 749:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(867);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 750:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(963);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 751:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(715);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 752:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(669);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 753:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(893);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 754:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(894);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 755:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(908);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 756:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(989);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 757:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(903);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 758:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(968);
-      if (lookahead == 't') ADVANCE(678);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 759:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(895);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 760:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(896);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 761:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(897);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 762:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(899);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 763:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'e') ADVANCE(703);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 736:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(860);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 737:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(882);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 738:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(704);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 739:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(857);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 740:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(953);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 741:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(705);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 742:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(659);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 743:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(883);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 744:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(884);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 745:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(898);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 746:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(979);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 747:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(893);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 748:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(958);
+      if (lookahead == 't') ADVANCE(668);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 749:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(885);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 750:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(886);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 751:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(887);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 752:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(889);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 753:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(693);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 754:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(949);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 755:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(823);
+      if (lookahead == 'i') ADVANCE(684);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 756:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(975);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 757:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(937);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 758:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(636);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 759:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(625);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 760:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(711);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 761:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(944);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 762:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'f') ADVANCE(495);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 763:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'f') ADVANCE(765);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 764:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(959);
+      if (lookahead == 'f') ADVANCE(801);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 765:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(833);
-      if (lookahead == 'i') ADVANCE(694);
+      if (lookahead == 'f') ADVANCE(743);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 766:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(985);
+      if (lookahead == 'f') ADVANCE(744);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 767:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(947);
+      if (lookahead == 'f') ADVANCE(671);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 768:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(646);
+      if (lookahead == 'f') ADVANCE(766);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 769:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(635);
+      if (lookahead == 'f') ADVANCE(796);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 770:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(721);
+      if (lookahead == 'g') ADVANCE(630);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 771:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(954);
+      if (lookahead == 'g') ADVANCE(544);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 772:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(504);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 773:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(775);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 774:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(811);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 775:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(753);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 776:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(754);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 777:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(681);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 778:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(776);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 779:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'f') ADVANCE(806);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 780:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(640);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 781:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'g') ADVANCE(554);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 773:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(556);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 774:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(552);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 775:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(803);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 776:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(854);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 777:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(799);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 778:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(650);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 779:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(875);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 780:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(684);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 781:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(863);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 782:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(564);
+      if (lookahead == 'i') ADVANCE(770);
+      if (lookahead == 'y') ADVANCE(965);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 783:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(566);
+      if (lookahead == 'i') ADVANCE(809);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 784:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(562);
+      if (lookahead == 'i') ADVANCE(775);
+      if (lookahead == 'o') ADVANCE(865);
+      if (lookahead == 'y') ADVANCE(967);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 785:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(813);
+      if (lookahead == 'i') ADVANCE(641);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 786:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(864);
+      if (lookahead == 'i') ADVANCE(686);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 787:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(809);
+      if (lookahead == 'i') ADVANCE(776);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 788:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(660);
+      if (lookahead == 'i') ADVANCE(678);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 789:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(885);
+      if (lookahead == 'i') ADVANCE(845);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 790:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(694);
+      if (lookahead == 'i') ADVANCE(848);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 791:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(873);
+      if (lookahead == 'i') ADVANCE(849);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 792:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(780);
-      if (lookahead == 'y') ADVANCE(975);
+      if (lookahead == 'i') ADVANCE(837);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 793:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(819);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 794:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(785);
-      if (lookahead == 'o') ADVANCE(875);
-      if (lookahead == 'y') ADVANCE(977);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 795:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(651);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 796:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(696);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 797:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(786);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 798:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(688);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 799:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(855);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 800:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'i') ADVANCE(858);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 794:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(720);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 795:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(960);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 796:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(752);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 797:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(810);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 798:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(948);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 799:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(769);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 800:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(907);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 801:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(859);
+      if (lookahead == 'i') ADVANCE(855);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 802:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(847);
+      if (lookahead == 'i') ADVANCE(698);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 803:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(868);
+      if (lookahead == 'i') ADVANCE(852);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 804:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(730);
+      if (lookahead == 'i') ADVANCE(876);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 805:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(970);
+      if (lookahead == 'i') ADVANCE(699);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 806:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(762);
+      if (lookahead == 'i') ADVANCE(861);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 807:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(820);
+      if (lookahead == 'j') ADVANCE(753);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 808:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(958);
+      if (lookahead == 'k') ADVANCE(454);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 809:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(779);
+      if (lookahead == 'k') ADVANCE(725);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 810:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(917);
+      if (lookahead == 'k') ADVANCE(726);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 811:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(865);
+      if (lookahead == 'l') ADVANCE(481);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 812:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(708);
+      if (lookahead == 'l') ADVANCE(526);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 813:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(862);
+      if (lookahead == 'l') ADVANCE(500);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 814:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(886);
+      if (lookahead == 'l') ADVANCE(870);
+      if (lookahead == 'r') ADVANCE(862);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 815:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(709);
+      if (lookahead == 'l') ADVANCE(680);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 816:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(871);
+      if (lookahead == 'l') ADVANCE(989);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 817:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'j') ADVANCE(763);
+      if (lookahead == 'l') ADVANCE(815);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 818:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'k') ADVANCE(463);
+      if (lookahead == 'l') ADVANCE(783);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 819:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'k') ADVANCE(735);
+      if (lookahead == 'l') ADVANCE(742);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 820:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'k') ADVANCE(736);
+      if (lookahead == 'l') ADVANCE(719);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 821:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(490);
+      if (lookahead == 'l') ADVANCE(1015);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 822:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(536);
+      if (lookahead == 'l') ADVANCE(759);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 823:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(509);
+      if (lookahead == 'l') ADVANCE(756);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 824:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(880);
-      if (lookahead == 'r') ADVANCE(872);
+      if (lookahead == 'l') ADVANCE(727);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 825:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(690);
+      if (lookahead == 'l') ADVANCE(648);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 826:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(999);
+      if (lookahead == 'l') ADVANCE(871);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 827:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(825);
+      if (lookahead == 'l') ADVANCE(797);
+      if (lookahead == 't') ADVANCE(750);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 828:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(793);
+      if (lookahead == 'm') ADVANCE(712);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 829:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(752);
+      if (lookahead == 'm') ADVANCE(465);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 830:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(729);
+      if (lookahead == 'm') ADVANCE(679);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 831:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(1025);
+      if (lookahead == 'm') ADVANCE(798);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 832:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(769);
+      if (lookahead == 'm') ADVANCE(880);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 833:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(766);
+      if (lookahead == 'n') ADVANCE(985);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 834:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(737);
+      if (lookahead == 'n') ADVANCE(707);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 835:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(658);
+      if (lookahead == 'n') ADVANCE(532);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 836:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(881);
+      if (lookahead == 'n') ADVANCE(691);
+      if (lookahead == 't') ADVANCE(757);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 837:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(807);
-      if (lookahead == 't') ADVANCE(760);
+      if (lookahead == 'n') ADVANCE(477);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 838:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(722);
+      if (lookahead == 'n') ADVANCE(999);
+      if (lookahead == 's') ADVANCE(1016);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 839:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(474);
+      if (lookahead == 'n') ADVANCE(685);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 840:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(689);
+      if (lookahead == 'n') ADVANCE(946);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 841:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(808);
+      if (lookahead == 'n') ADVANCE(771);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 842:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(890);
+      if (lookahead == 'n') ADVANCE(950);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 843:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(995);
+      if (lookahead == 'n') ADVANCE(643);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 844:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(717);
+      if (lookahead == 'n') ADVANCE(962);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 845:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(542);
+      if (lookahead == 'n') ADVANCE(772);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 846:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(701);
-      if (lookahead == 't') ADVANCE(767);
+      if (lookahead == 'n') ADVANCE(692);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 847:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(486);
+      if (lookahead == 'n') ADVANCE(943);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 848:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(1009);
-      if (lookahead == 's') ADVANCE(1026);
+      if (lookahead == 'n') ADVANCE(773);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 849:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(774);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 850:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(963);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 851:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(821);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 852:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(955);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 853:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(916);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 854:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(734);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 855:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(735);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 856:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(651);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 857:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'n') ADVANCE(695);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 850:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(956);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 851:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(781);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 852:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(960);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 853:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(653);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 854:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(972);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 855:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(782);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 856:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(702);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 857:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(953);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 858:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(783);
+      if (lookahead == 'n') ADVANCE(777);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 859:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(784);
+      if (lookahead == 'n') ADVANCE(947);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 860:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(973);
+      if (lookahead == 'n') ADVANCE(617);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 861:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(831);
+      if (lookahead == 'n') ADVANCE(984);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 862:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(965);
+      if (lookahead == 'o') ADVANCE(1018);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 863:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(926);
+      if (lookahead == 'o') ADVANCE(843);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 864:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(744);
+      if (lookahead == 'o') ADVANCE(986);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 865:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(745);
+      if (lookahead == 'o') ADVANCE(819);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 866:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(661);
+      if (lookahead == 'o') ADVANCE(831);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 867:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(705);
+      if (lookahead == 'o') ADVANCE(812);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 868:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(787);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 869:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(957);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 870:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(627);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 871:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(994);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 872:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(1028);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 873:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(853);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 874:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(996);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 875:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(829);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 876:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'o') ADVANCE(841);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 877:
+    case 869:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(822);
+      if (lookahead == 'o') ADVANCE(891);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 878:
+    case 870:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(653);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 871:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(656);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 872:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(840);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 873:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'o') ADVANCE(851);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 874:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(888);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 875:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(897);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 876:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(856);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 877:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'p') ADVANCE(713);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 878:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'p') ADVANCE(642);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 879:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(901);
+      if (lookahead == 'p') ADVANCE(818);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 880:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(663);
+      if (lookahead == 'p') ADVANCE(760);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 881:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(666);
+      if (lookahead == 'q') ADVANCE(990);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 882:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(850);
+      if (lookahead == 'r') ADVANCE(994);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 883:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(861);
+      if (lookahead == 'r') ADVANCE(563);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 884:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(898);
+      if (lookahead == 'r') ADVANCE(565);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 885:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(907);
+      if (lookahead == 'r') ADVANCE(467);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 886:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(866);
+      if (lookahead == 'r') ADVANCE(489);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 887:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(723);
+      if (lookahead == 'r') ADVANCE(461);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 888:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(652);
+      if (lookahead == 'r') ADVANCE(459);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 889:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(828);
+      if (lookahead == 'r') ADVANCE(493);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 890:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(770);
+      if (lookahead == 'r') ADVANCE(998);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 891:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'q') ADVANCE(1000);
+      if (lookahead == 'r') ADVANCE(700);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 892:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(1004);
+      if (lookahead == 'r') ADVANCE(895);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 893:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(573);
+      if (lookahead == 'r') ADVANCE(767);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 894:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(575);
+      if (lookahead == 'r') ADVANCE(866);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 895:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(476);
+      if (lookahead == 'r') ADVANCE(646);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 896:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(498);
+      if (lookahead == 'r') ADVANCE(788);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 897:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(470);
+      if (lookahead == 'r') ADVANCE(954);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 898:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(468);
+      if (lookahead == 'r') ADVANCE(795);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 899:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(502);
+      if (lookahead == 'r') ADVANCE(649);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 900:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(1008);
+      if (lookahead == 'r') ADVANCE(730);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 901:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(710);
+      if (lookahead == 'r') ADVANCE(652);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 902:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(905);
+      if (lookahead == 'r') ADVANCE(655);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 903:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(777);
+      if (lookahead == 'r') ADVANCE(658);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 904:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(876);
+      if (lookahead == 'r') ADVANCE(660);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 905:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(656);
+      if (lookahead == 'r') ADVANCE(661);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 906:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(798);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 907:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(964);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 908:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(805);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 909:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(659);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 910:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(740);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 911:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'r') ADVANCE(662);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 912:
+    case 907:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(732);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 908:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(663);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 909:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(664);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 910:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'r') ADVANCE(665);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 913:
+    case 911:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(668);
+      if (lookahead == 'r') ADVANCE(666);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 912:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(667);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 913:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(669);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 914:
       ACCEPT_TOKEN(sym_identifier);
@@ -6883,151 +6933,151 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 915:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(671);
+      if (lookahead == 'r') ADVANCE(964);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 916:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(672);
+      if (lookahead == 'r') ADVANCE(754);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 917:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(742);
+      if (lookahead == 'r') ADVANCE(899);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 918:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(673);
+      if (lookahead == 'r') ADVANCE(789);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 919:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(674);
+      if (lookahead == 'r') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 920:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(675);
+      if (lookahead == 'r') ADVANCE(790);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 921:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(676);
+      if (lookahead == 'r') ADVANCE(902);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 922:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(677);
+      if (lookahead == 'r') ADVANCE(791);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 923:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(679);
+      if (lookahead == 'r') ADVANCE(903);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 924:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(680);
+      if (lookahead == 'r') ADVANCE(904);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 925:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(974);
+      if (lookahead == 'r') ADVANCE(905);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 926:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(764);
+      if (lookahead == 'r') ADVANCE(906);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 927:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(908);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 928:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'r') ADVANCE(909);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 928:
+    case 929:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(799);
+      if (lookahead == 'r') ADVANCE(910);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 929:
+    case 930:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'r') ADVANCE(911);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 930:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(800);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 931:
       ACCEPT_TOKEN(sym_identifier);
@@ -7036,909 +7086,819 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 932:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(801);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 933:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'r') ADVANCE(913);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 934:
+    case 933:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'r') ADVANCE(914);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 934:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(802);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 935:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(915);
+      if (lookahead == 'r') ADVANCE(805);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 936:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(916);
+      if (lookahead == 'r') ADVANCE(674);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 937:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(918);
+      if (lookahead == 'r') ADVANCE(673);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 938:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(919);
+      if (lookahead == 'r') ADVANCE(936);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 939:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(920);
+      if (lookahead == 's') ADVANCE(448);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 940:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(921);
+      if (lookahead == 's') ADVANCE(878);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 941:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(922);
+      if (lookahead == 's') ADVANCE(1016);
+      if (lookahead == 't') ADVANCE(972);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 942:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(923);
+      if (lookahead == 's') ADVANCE(1016);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 943:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(924);
+      if (lookahead == 's') ADVANCE(787);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 944:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(812);
+      if (lookahead == 's') ADVANCE(968);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 945:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(815);
+      if (lookahead == 's') ADVANCE(737);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 946:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(684);
+      if (lookahead == 's') ADVANCE(957);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 947:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(683);
+      if (lookahead == 's') ADVANCE(959);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 948:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(946);
+      if (lookahead == 's') ADVANCE(721);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 949:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(457);
+      if (lookahead == 's') ADVANCE(983);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 950:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(888);
+      if (lookahead == 't') ADVANCE(599);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 951:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(1026);
-      if (lookahead == 't') ADVANCE(982);
+      if (lookahead == 't') ADVANCE(601);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 952:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(1026);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 953:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(797);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 954:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(978);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 955:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(747);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 956:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(967);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 957:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(969);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 958:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(731);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 959:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(993);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 960:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(609);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 961:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(611);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 962:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(558);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 963:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(546);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 964:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(552);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 965:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 't') ADVANCE(548);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 953:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(536);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 954:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(542);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 955:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(538);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 956:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(524);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 957:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(457);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 958:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(827);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 959:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(456);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 960:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(469);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 961:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(781);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 962:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(600);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 963:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(611);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 964:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(785);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 965:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(758);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 966:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(534);
+      if (lookahead == 't') ADVANCE(644);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 967:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(466);
+      if (lookahead == 't') ADVANCE(718);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 968:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(837);
+      if (lookahead == 't') ADVANCE(934);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 969:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(465);
+      if (lookahead == 't') ADVANCE(918);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 970:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(478);
+      if (lookahead == 't') ADVANCE(740);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 971:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(791);
+      if (lookahead == 't') ADVANCE(874);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 972:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(610);
+      if (lookahead == 't') ADVANCE(896);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 973:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(621);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 974:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(795);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 975:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(768);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 976:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(654);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 977:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(728);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 978:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(944);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 979:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(928);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 980:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(750);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 981:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(884);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 982:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(906);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 983:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(748);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 984:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(759);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 985:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(761);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 986:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 't') ADVANCE(738);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 987:
+    case 974:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(749);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 975:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 't') ADVANCE(751);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 976:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(728);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 977:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(741);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 978:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(786);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 979:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(974);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 980:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(804);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 981:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(920);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 982:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(922);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 983:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(935);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 984:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(612);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 985:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(829);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 986:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(681);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 987:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(763);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 988:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(796);
+      if (lookahead == 'u') ADVANCE(800);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 989:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(984);
+      if (lookahead == 'u') ADVANCE(708);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 990:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(814);
+      if (lookahead == 'u') ADVANCE(739);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 991:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(930);
+      if (lookahead == 'u') ADVANCE(694);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 992:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(932);
+      if (lookahead == 'u') ADVANCE(976);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 993:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(945);
+      if (lookahead == 'u') ADVANCE(768);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 994:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(622);
+      if (lookahead == 'v') ADVANCE(672);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 995:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(839);
+      if (lookahead == 'w') ADVANCE(567);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 996:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(691);
+      if (lookahead == 'x') ADVANCE(792);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 997:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(773);
+      if (lookahead == 'y') ADVANCE(877);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 998:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(810);
+      if (lookahead == 'y') ADVANCE(463);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 999:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(718);
+      if (lookahead == 'y') ADVANCE(518);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 1000:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(749);
+      if (lookahead == 'y') ADVANCE(628);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 1001:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(704);
+      if (lookahead == 'y') ADVANCE(569);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 1002:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(986);
+      if (lookahead == 'y') ADVANCE(571);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 1003:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(778);
+      if (lookahead == 'y') ADVANCE(573);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 1004:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'v') ADVANCE(682);
+      if (lookahead == 'y') ADVANCE(575);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
     case 1005:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'w') ADVANCE(577);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1006:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'x') ADVANCE(802);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1007:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(887);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1008:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(472);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1009:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'y') ADVANCE(528);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1010:
+    case 1006:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(638);
+      if (lookahead == 'y') ADVANCE(577);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1011:
+    case 1007:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'y') ADVANCE(579);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1012:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(581);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1013:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(583);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1014:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(585);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1015:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(538);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1016:
+    case 1008:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'y') ADVANCE(587);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1017:
+    case 1009:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'y') ADVANCE(589);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1018:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(597);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1019:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(599);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1020:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(601);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1021:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(593);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1022:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(595);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1023:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(540);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
-      END_STATE();
-    case 1024:
+    case 1010:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'y') ADVANCE(591);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1025:
+    case 1011:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(492);
+      if (lookahead == 'y') ADVANCE(583);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1026:
+    case 1012:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(849);
+      if (lookahead == 'y') ADVANCE(585);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1027:
+    case 1013:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'y') ADVANCE(639);
+      if (lookahead == 'y') ADVANCE(530);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1028:
+    case 1014:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'z') ADVANCE(746);
+      if (lookahead == 'y') ADVANCE(581);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'y')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1029:
+    case 1015:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(483);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 1016:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(839);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 1017:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(629);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
+      END_STATE();
+    case 1018:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'z') ADVANCE(736);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'y')) ADVANCE(1019);
+      END_STATE();
+    case 1019:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1029);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(1019);
       END_STATE();
-    case 1030:
+    case 1020:
       ACCEPT_TOKEN(sym_string);
       END_STATE();
-    case 1031:
+    case 1021:
       ACCEPT_TOKEN(sym__whitespace);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(1031);
+          lookahead == ' ') ADVANCE(1021);
       END_STATE();
-    case 1032:
+    case 1022:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead == '*') ADVANCE(11);
       if (lookahead != 0) ADVANCE(12);
       END_STATE();
-    case 1033:
+    case 1023:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(1033);
+          lookahead != '\n') ADVANCE(1023);
       END_STATE();
     default:
       return false;
@@ -7947,7 +7907,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 451},
+  [1] = {.lex_state = 442},
   [2] = {.lex_state = 5},
   [3] = {.lex_state = 5},
   [4] = {.lex_state = 5},
@@ -7965,11 +7925,11 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [16] = {.lex_state = 6},
   [17] = {.lex_state = 6},
   [18] = {.lex_state = 8},
-  [19] = {.lex_state = 6},
+  [19] = {.lex_state = 8},
   [20] = {.lex_state = 6},
   [21] = {.lex_state = 6},
   [22] = {.lex_state = 8},
-  [23] = {.lex_state = 8},
+  [23] = {.lex_state = 6},
   [24] = {.lex_state = 6},
   [25] = {.lex_state = 6},
   [26] = {.lex_state = 6},
@@ -8032,128 +7992,128 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [83] = {.lex_state = 19},
   [84] = {.lex_state = 19},
   [85] = {.lex_state = 19},
-  [86] = {.lex_state = 21},
-  [87] = {.lex_state = 451},
-  [88] = {.lex_state = 451},
-  [89] = {.lex_state = 0},
-  [90] = {.lex_state = 451},
-  [91] = {.lex_state = 451},
-  [92] = {.lex_state = 451},
-  [93] = {.lex_state = 451},
-  [94] = {.lex_state = 451},
-  [95] = {.lex_state = 451},
-  [96] = {.lex_state = 451},
-  [97] = {.lex_state = 451},
+  [86] = {.lex_state = 0},
+  [87] = {.lex_state = 21},
+  [88] = {.lex_state = 442},
+  [89] = {.lex_state = 442},
+  [90] = {.lex_state = 0},
+  [91] = {.lex_state = 2},
+  [92] = {.lex_state = 442},
+  [93] = {.lex_state = 442},
+  [94] = {.lex_state = 442},
+  [95] = {.lex_state = 442},
+  [96] = {.lex_state = 442},
+  [97] = {.lex_state = 442},
   [98] = {.lex_state = 2},
-  [99] = {.lex_state = 451},
-  [100] = {.lex_state = 2},
-  [101] = {.lex_state = 2},
-  [102] = {.lex_state = 451},
-  [103] = {.lex_state = 451},
-  [104] = {.lex_state = 0},
-  [105] = {.lex_state = 451},
-  [106] = {.lex_state = 451},
+  [99] = {.lex_state = 442},
+  [100] = {.lex_state = 442},
+  [101] = {.lex_state = 442},
+  [102] = {.lex_state = 2},
+  [103] = {.lex_state = 442},
+  [104] = {.lex_state = 442},
+  [105] = {.lex_state = 442},
+  [106] = {.lex_state = 442},
   [107] = {.lex_state = 4},
-  [108] = {.lex_state = 2},
+  [108] = {.lex_state = 3},
   [109] = {.lex_state = 3},
-  [110] = {.lex_state = 3},
-  [111] = {.lex_state = 2},
-  [112] = {.lex_state = 2},
-  [113] = {.lex_state = 2},
-  [114] = {.lex_state = 2},
+  [110] = {.lex_state = 2},
+  [111] = {.lex_state = 0},
+  [112] = {.lex_state = 4},
+  [113] = {.lex_state = 4},
+  [114] = {.lex_state = 4},
   [115] = {.lex_state = 2},
-  [116] = {.lex_state = 0},
-  [117] = {.lex_state = 2},
-  [118] = {.lex_state = 2},
-  [119] = {.lex_state = 0},
-  [120] = {.lex_state = 4},
+  [116] = {.lex_state = 4},
+  [117] = {.lex_state = 0},
+  [118] = {.lex_state = 4},
+  [119] = {.lex_state = 4},
+  [120] = {.lex_state = 2},
   [121] = {.lex_state = 0},
-  [122] = {.lex_state = 4},
+  [122] = {.lex_state = 2},
   [123] = {.lex_state = 4},
   [124] = {.lex_state = 4},
   [125] = {.lex_state = 4},
-  [126] = {.lex_state = 4},
-  [127] = {.lex_state = 0},
+  [126] = {.lex_state = 2},
+  [127] = {.lex_state = 2},
   [128] = {.lex_state = 4},
   [129] = {.lex_state = 4},
-  [130] = {.lex_state = 4},
-  [131] = {.lex_state = 4},
+  [130] = {.lex_state = 2},
+  [131] = {.lex_state = 0},
   [132] = {.lex_state = 4},
   [133] = {.lex_state = 4},
-  [134] = {.lex_state = 4},
+  [134] = {.lex_state = 2},
   [135] = {.lex_state = 2},
   [136] = {.lex_state = 2},
-  [137] = {.lex_state = 0},
-  [138] = {.lex_state = 2},
-  [139] = {.lex_state = 0},
+  [137] = {.lex_state = 2},
+  [138] = {.lex_state = 0},
+  [139] = {.lex_state = 2},
   [140] = {.lex_state = 2},
-  [141] = {.lex_state = 0},
-  [142] = {.lex_state = 2},
-  [143] = {.lex_state = 2},
+  [141] = {.lex_state = 2},
+  [142] = {.lex_state = 0},
+  [143] = {.lex_state = 0},
   [144] = {.lex_state = 0},
   [145] = {.lex_state = 0},
   [146] = {.lex_state = 4},
   [147] = {.lex_state = 0},
-  [148] = {.lex_state = 4},
+  [148] = {.lex_state = 2},
   [149] = {.lex_state = 0},
   [150] = {.lex_state = 0},
   [151] = {.lex_state = 0},
-  [152] = {.lex_state = 4},
-  [153] = {.lex_state = 20},
+  [152] = {.lex_state = 0},
+  [153] = {.lex_state = 0},
   [154] = {.lex_state = 0},
   [155] = {.lex_state = 0},
-  [156] = {.lex_state = 4},
-  [157] = {.lex_state = 0},
+  [156] = {.lex_state = 0},
+  [157] = {.lex_state = 2},
   [158] = {.lex_state = 0},
-  [159] = {.lex_state = 0},
-  [160] = {.lex_state = 2},
+  [159] = {.lex_state = 2},
+  [160] = {.lex_state = 0},
   [161] = {.lex_state = 2},
   [162] = {.lex_state = 0},
   [163] = {.lex_state = 0},
   [164] = {.lex_state = 0},
-  [165] = {.lex_state = 4},
+  [165] = {.lex_state = 0},
   [166] = {.lex_state = 0},
-  [167] = {.lex_state = 2},
-  [168] = {.lex_state = 20},
+  [167] = {.lex_state = 0},
+  [168] = {.lex_state = 0},
   [169] = {.lex_state = 0},
-  [170] = {.lex_state = 0},
-  [171] = {.lex_state = 2},
-  [172] = {.lex_state = 4},
+  [170] = {.lex_state = 2},
+  [171] = {.lex_state = 20},
+  [172] = {.lex_state = 0},
   [173] = {.lex_state = 0},
-  [174] = {.lex_state = 2},
-  [175] = {.lex_state = 0},
-  [176] = {.lex_state = 2},
+  [174] = {.lex_state = 0},
+  [175] = {.lex_state = 4},
+  [176] = {.lex_state = 0},
   [177] = {.lex_state = 0},
-  [178] = {.lex_state = 0},
+  [178] = {.lex_state = 4},
   [179] = {.lex_state = 0},
   [180] = {.lex_state = 0},
   [181] = {.lex_state = 0},
-  [182] = {.lex_state = 0},
+  [182] = {.lex_state = 4},
   [183] = {.lex_state = 0},
-  [184] = {.lex_state = 0},
-  [185] = {.lex_state = 2},
+  [184] = {.lex_state = 4},
+  [185] = {.lex_state = 4},
   [186] = {.lex_state = 0},
   [187] = {.lex_state = 0},
   [188] = {.lex_state = 0},
-  [189] = {.lex_state = 0},
-  [190] = {.lex_state = 2},
+  [189] = {.lex_state = 2},
+  [190] = {.lex_state = 0},
   [191] = {.lex_state = 2},
-  [192] = {.lex_state = 0},
+  [192] = {.lex_state = 20},
   [193] = {.lex_state = 0},
   [194] = {.lex_state = 0},
   [195] = {.lex_state = 0},
   [196] = {.lex_state = 0},
-  [197] = {.lex_state = 0},
-  [198] = {.lex_state = 4},
-  [199] = {.lex_state = 0},
-  [200] = {.lex_state = 0},
+  [197] = {.lex_state = 2},
+  [198] = {.lex_state = 0},
+  [199] = {.lex_state = 2},
+  [200] = {.lex_state = 4},
   [201] = {.lex_state = 0},
   [202] = {.lex_state = 0},
-  [203] = {.lex_state = 2},
+  [203] = {.lex_state = 0},
   [204] = {.lex_state = 0},
   [205] = {.lex_state = 0},
   [206] = {.lex_state = 0},
-  [207] = {.lex_state = 0},
+  [207] = {.lex_state = 2},
   [208] = {.lex_state = 0},
   [209] = {.lex_state = 0},
   [210] = {.lex_state = 0},
@@ -8177,45 +8137,45 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [228] = {.lex_state = 0},
   [229] = {.lex_state = 0},
   [230] = {.lex_state = 0},
-  [231] = {.lex_state = 2},
+  [231] = {.lex_state = 0},
   [232] = {.lex_state = 0},
   [233] = {.lex_state = 2},
   [234] = {.lex_state = 0},
   [235] = {.lex_state = 0},
-  [236] = {.lex_state = 0},
-  [237] = {.lex_state = 2},
+  [236] = {.lex_state = 2},
+  [237] = {.lex_state = 0},
   [238] = {.lex_state = 0},
   [239] = {.lex_state = 0},
   [240] = {.lex_state = 0},
   [241] = {.lex_state = 0},
   [242] = {.lex_state = 0},
   [243] = {.lex_state = 0},
-  [244] = {.lex_state = 2},
+  [244] = {.lex_state = 0},
   [245] = {.lex_state = 0},
   [246] = {.lex_state = 0},
-  [247] = {.lex_state = 0},
-  [248] = {.lex_state = 2},
+  [247] = {.lex_state = 2},
+  [248] = {.lex_state = 0},
   [249] = {.lex_state = 0},
   [250] = {.lex_state = 0},
   [251] = {.lex_state = 0},
   [252] = {.lex_state = 0},
-  [253] = {.lex_state = 0},
-  [254] = {.lex_state = 2},
+  [253] = {.lex_state = 2},
+  [254] = {.lex_state = 0},
   [255] = {.lex_state = 0},
   [256] = {.lex_state = 0},
   [257] = {.lex_state = 0},
   [258] = {.lex_state = 0},
-  [259] = {.lex_state = 0},
-  [260] = {.lex_state = 0},
+  [259] = {.lex_state = 2},
+  [260] = {.lex_state = 2},
   [261] = {.lex_state = 0},
   [262] = {.lex_state = 0},
   [263] = {.lex_state = 0},
-  [264] = {.lex_state = 2},
+  [264] = {.lex_state = 0},
   [265] = {.lex_state = 0},
-  [266] = {.lex_state = 0},
+  [266] = {.lex_state = 2},
   [267] = {.lex_state = 0},
   [268] = {.lex_state = 0},
-  [269] = {.lex_state = 0},
+  [269] = {.lex_state = 2},
   [270] = {.lex_state = 0},
   [271] = {.lex_state = 0},
   [272] = {.lex_state = 0},
@@ -8223,11 +8183,11 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [274] = {.lex_state = 0},
   [275] = {.lex_state = 0},
   [276] = {.lex_state = 0},
-  [277] = {.lex_state = 2},
-  [278] = {.lex_state = 2},
+  [277] = {.lex_state = 0},
+  [278] = {.lex_state = 0},
   [279] = {.lex_state = 0},
-  [280] = {.lex_state = 0},
-  [281] = {.lex_state = 0},
+  [280] = {.lex_state = 2},
+  [281] = {.lex_state = 2},
   [282] = {.lex_state = 0},
   [283] = {.lex_state = 0},
   [284] = {.lex_state = 0},
@@ -8238,17 +8198,17 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [289] = {.lex_state = 0},
   [290] = {.lex_state = 0},
   [291] = {.lex_state = 0},
-  [292] = {.lex_state = 0},
-  [293] = {.lex_state = 2},
+  [292] = {.lex_state = 2},
+  [293] = {.lex_state = 0},
   [294] = {.lex_state = 0},
   [295] = {.lex_state = 0},
-  [296] = {.lex_state = 2},
+  [296] = {.lex_state = 0},
   [297] = {.lex_state = 0},
   [298] = {.lex_state = 0},
   [299] = {.lex_state = 0},
   [300] = {.lex_state = 0},
   [301] = {.lex_state = 0},
-  [302] = {.lex_state = 0},
+  [302] = {.lex_state = 2},
   [303] = {.lex_state = 0},
   [304] = {.lex_state = 0},
   [305] = {.lex_state = 0},
@@ -8262,7 +8222,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [313] = {.lex_state = 0},
   [314] = {.lex_state = 0},
   [315] = {.lex_state = 0},
-  [316] = {.lex_state = 2},
+  [316] = {.lex_state = 0},
   [317] = {.lex_state = 0},
   [318] = {.lex_state = 0},
   [319] = {.lex_state = 0},
@@ -8270,8 +8230,6 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [321] = {.lex_state = 0},
   [322] = {.lex_state = 0},
   [323] = {.lex_state = 0},
-  [324] = {.lex_state = 0},
-  [325] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -8312,7 +8270,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_RBRACE] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
-    [anon_sym_ConstValue] = ACTIONS(1),
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_null] = ACTIONS(1),
@@ -8370,14 +8327,14 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_comment] = ACTIONS(3),
   },
   [STATE(1)] = {
-    [sym_source_file] = STATE(234),
-    [sym__definition] = STATE(87),
-    [sym_namespace_statement] = STATE(91),
-    [sym_dictionary_statement] = STATE(91),
-    [sym_enum_statement] = STATE(91),
-    [sym_includes_statement] = STATE(91),
-    [sym_typedef_statement] = STATE(91),
-    [aux_sym_source_file_repeat1] = STATE(87),
+    [sym_source_file] = STATE(288),
+    [sym__definition] = STATE(88),
+    [sym_namespace_statement] = STATE(92),
+    [sym_dictionary_statement] = STATE(92),
+    [sym_enum_statement] = STATE(92),
+    [sym_includes_statement] = STATE(92),
+    [sym_typedef_statement] = STATE(92),
+    [aux_sym_source_file_repeat1] = STATE(88),
     [ts_builtin_sym_end] = ACTIONS(5),
     [anon_sym_dictionary] = ACTIONS(7),
     [anon_sym_enum] = ACTIONS(9),
@@ -8420,9 +8377,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -8433,7 +8390,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(4), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -8444,7 +8401,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -8458,7 +8415,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -8508,9 +8465,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -8518,10 +8475,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(6), 2,
+    STATE(8), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -8532,7 +8489,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -8546,7 +8503,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -8590,15 +8547,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_promise,
     ACTIONS(51), 1,
       anon_sym_record,
-    ACTIONS(55), 1,
+    ACTIONS(57), 1,
       anon_sym_RBRACE,
     STATE(32), 1,
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -8606,10 +8563,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(5), 2,
+    STATE(8), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -8620,7 +8577,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -8634,7 +8591,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -8656,78 +8613,78 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [345] = 27,
-    ACTIONS(57), 1,
+    ACTIONS(19), 1,
       anon_sym_LPAREN,
-    ACTIONS(60), 1,
+    ACTIONS(21), 1,
       anon_sym_async,
-    ACTIONS(63), 1,
+    ACTIONS(23), 1,
       anon_sym_required,
-    ACTIONS(66), 1,
-      anon_sym_RBRACE,
-    ACTIONS(68), 1,
+    ACTIONS(27), 1,
       anon_sym_LBRACK,
-    ACTIONS(74), 1,
+    ACTIONS(31), 1,
       anon_sym_any,
-    ACTIONS(83), 1,
+    ACTIONS(37), 1,
       anon_sym_unsigned,
-    ACTIONS(86), 1,
+    ACTIONS(39), 1,
       anon_sym_short,
-    ACTIONS(89), 1,
+    ACTIONS(41), 1,
       anon_sym_long,
-    ACTIONS(92), 1,
+    ACTIONS(43), 1,
       anon_sym_restricted,
-    ACTIONS(101), 1,
+    ACTIONS(49), 1,
       anon_sym_promise,
-    ACTIONS(104), 1,
+    ACTIONS(51), 1,
       anon_sym_record,
+    ACTIONS(57), 1,
+      anon_sym_RBRACE,
     STATE(32), 1,
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(95), 2,
+    ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(5), 2,
+    STATE(3), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(77), 3,
+    ACTIONS(33), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(98), 3,
+    ACTIONS(47), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(71), 4,
+    ACTIONS(29), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(80), 4,
+    ACTIONS(35), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(107), 15,
+    ACTIONS(53), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -8766,15 +8723,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_promise,
     ACTIONS(51), 1,
       anon_sym_record,
-    ACTIONS(110), 1,
+    ACTIONS(59), 1,
       anon_sym_RBRACE,
     STATE(32), 1,
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -8782,10 +8739,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(5), 2,
+    STATE(8), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -8796,7 +8753,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -8810,7 +8767,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -8854,15 +8811,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_promise,
     ACTIONS(51), 1,
       anon_sym_record,
-    ACTIONS(112), 1,
+    ACTIONS(61), 1,
       anon_sym_RBRACE,
     STATE(32), 1,
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -8870,10 +8827,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(5), 2,
+    STATE(6), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -8884,7 +8841,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -8898,7 +8855,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -8920,78 +8877,78 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [690] = 27,
-    ACTIONS(19), 1,
+    ACTIONS(63), 1,
       anon_sym_LPAREN,
-    ACTIONS(21), 1,
+    ACTIONS(66), 1,
       anon_sym_async,
-    ACTIONS(23), 1,
+    ACTIONS(69), 1,
       anon_sym_required,
-    ACTIONS(27), 1,
-      anon_sym_LBRACK,
-    ACTIONS(31), 1,
-      anon_sym_any,
-    ACTIONS(37), 1,
-      anon_sym_unsigned,
-    ACTIONS(39), 1,
-      anon_sym_short,
-    ACTIONS(41), 1,
-      anon_sym_long,
-    ACTIONS(43), 1,
-      anon_sym_restricted,
-    ACTIONS(49), 1,
-      anon_sym_promise,
-    ACTIONS(51), 1,
-      anon_sym_record,
-    ACTIONS(114), 1,
+    ACTIONS(72), 1,
       anon_sym_RBRACE,
+    ACTIONS(74), 1,
+      anon_sym_LBRACK,
+    ACTIONS(80), 1,
+      anon_sym_any,
+    ACTIONS(89), 1,
+      anon_sym_unsigned,
+    ACTIONS(92), 1,
+      anon_sym_short,
+    ACTIONS(95), 1,
+      anon_sym_long,
+    ACTIONS(98), 1,
+      anon_sym_restricted,
+    ACTIONS(107), 1,
+      anon_sym_promise,
+    ACTIONS(110), 1,
+      anon_sym_record,
     STATE(32), 1,
       sym_extended_attribute_list,
     STATE(49), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(45), 2,
+    ACTIONS(101), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(7), 2,
+    STATE(8), 2,
       aux_sym__dictionary_members,
       sym_dictionary_member,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(33), 3,
+    ACTIONS(83), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(47), 3,
+    ACTIONS(104), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(29), 4,
+    ACTIONS(77), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(35), 4,
+    ACTIONS(86), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(53), 15,
+    ACTIONS(113), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -9032,7 +8989,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_record,
     STATE(107), 1,
       sym_type,
-    STATE(120), 1,
+    STATE(124), 1,
       sym_union_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9040,13 +8997,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(140), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(10), 2,
+    STATE(13), 2,
       aux_sym__namespace_members,
       sym_namespace_member,
-    STATE(52), 2,
+    STATE(53), 2,
       sym_regular_operation,
       sym_const_statement,
-    STATE(123), 2,
+    STATE(113), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(128), 3,
@@ -9057,7 +9014,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(148), 3,
+    STATE(200), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9071,7 +9028,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(122), 4,
+    STATE(112), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -9093,91 +9050,6 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [915] = 25,
-    ACTIONS(150), 1,
-      anon_sym_LPAREN,
-    ACTIONS(153), 1,
-      anon_sym_async,
-    ACTIONS(156), 1,
-      anon_sym_const,
-    ACTIONS(159), 1,
-      anon_sym_RBRACE,
-    ACTIONS(164), 1,
-      anon_sym_any,
-    ACTIONS(173), 1,
-      anon_sym_unsigned,
-    ACTIONS(176), 1,
-      anon_sym_short,
-    ACTIONS(179), 1,
-      anon_sym_long,
-    ACTIONS(182), 1,
-      anon_sym_restricted,
-    ACTIONS(191), 1,
-      anon_sym_promise,
-    ACTIONS(194), 1,
-      anon_sym_record,
-    STATE(107), 1,
-      sym_type,
-    STATE(120), 1,
-      sym_union_type,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(185), 2,
-      anon_sym_float,
-      anon_sym_double,
-    STATE(10), 2,
-      aux_sym__namespace_members,
-      sym_namespace_member,
-    STATE(52), 2,
-      sym_regular_operation,
-      sym_const_statement,
-    STATE(123), 2,
-      sym_integer_type,
-      sym_float_type,
-    ACTIONS(167), 3,
-      anon_sym_sequence,
-      anon_sym_FrozenArray,
-      anon_sym_ObservableArray,
-    ACTIONS(188), 3,
-      anon_sym_ByteString,
-      anon_sym_DOMString,
-      anon_sym_USVString,
-    STATE(148), 3,
-      sym__single_type,
-      sym_distinguishable_type,
-      sym_promise_type,
-    ACTIONS(161), 4,
-      anon_sym_undefined,
-      anon_sym_object,
-      anon_sym_symbol,
-      sym_identifier,
-    ACTIONS(170), 4,
-      anon_sym_boolean,
-      anon_sym_byte,
-      anon_sym_octet,
-      anon_sym_bigint,
-    STATE(122), 4,
-      sym_primitive_type,
-      sym_string_type,
-      sym_record_type,
-      sym_buffer_related_type,
-    ACTIONS(197), 15,
-      anon_sym_ArrayBuffer,
-      anon_sym_SharedArrayBuffer,
-      anon_sym_DataView,
-      anon_sym_Int8Array,
-      anon_sym_Int16Array,
-      anon_sym_Int32Array,
-      anon_sym_Uint8Array,
-      anon_sym_Uint16Array,
-      anon_sym_Uint32Array,
-      anon_sym_Uint8ClampedArray,
-      anon_sym_BigInt64Array,
-      anon_sym_BigUint64Array,
-      anon_sym_Float16Array,
-      anon_sym_Float32Array,
-      anon_sym_Float64Array,
-  [1025] = 25,
     ACTIONS(116), 1,
       anon_sym_LPAREN,
     ACTIONS(118), 1,
@@ -9198,11 +9070,11 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_promise,
     ACTIONS(146), 1,
       anon_sym_record,
-    ACTIONS(200), 1,
+    ACTIONS(150), 1,
       anon_sym_RBRACE,
     STATE(107), 1,
       sym_type,
-    STATE(120), 1,
+    STATE(124), 1,
       sym_union_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9210,13 +9082,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(140), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(10), 2,
+    STATE(12), 2,
       aux_sym__namespace_members,
       sym_namespace_member,
-    STATE(52), 2,
+    STATE(53), 2,
       sym_regular_operation,
       sym_const_statement,
-    STATE(123), 2,
+    STATE(113), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(128), 3,
@@ -9227,7 +9099,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(148), 3,
+    STATE(200), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9241,12 +9113,97 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(122), 4,
+    STATE(112), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
     ACTIONS(148), 15,
+      anon_sym_ArrayBuffer,
+      anon_sym_SharedArrayBuffer,
+      anon_sym_DataView,
+      anon_sym_Int8Array,
+      anon_sym_Int16Array,
+      anon_sym_Int32Array,
+      anon_sym_Uint8Array,
+      anon_sym_Uint16Array,
+      anon_sym_Uint32Array,
+      anon_sym_Uint8ClampedArray,
+      anon_sym_BigInt64Array,
+      anon_sym_BigUint64Array,
+      anon_sym_Float16Array,
+      anon_sym_Float32Array,
+      anon_sym_Float64Array,
+  [1025] = 25,
+    ACTIONS(152), 1,
+      anon_sym_LPAREN,
+    ACTIONS(155), 1,
+      anon_sym_async,
+    ACTIONS(158), 1,
+      anon_sym_const,
+    ACTIONS(161), 1,
+      anon_sym_RBRACE,
+    ACTIONS(166), 1,
+      anon_sym_any,
+    ACTIONS(175), 1,
+      anon_sym_unsigned,
+    ACTIONS(178), 1,
+      anon_sym_short,
+    ACTIONS(181), 1,
+      anon_sym_long,
+    ACTIONS(184), 1,
+      anon_sym_restricted,
+    ACTIONS(193), 1,
+      anon_sym_promise,
+    ACTIONS(196), 1,
+      anon_sym_record,
+    STATE(107), 1,
+      sym_type,
+    STATE(124), 1,
+      sym_union_type,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(187), 2,
+      anon_sym_float,
+      anon_sym_double,
+    STATE(11), 2,
+      aux_sym__namespace_members,
+      sym_namespace_member,
+    STATE(53), 2,
+      sym_regular_operation,
+      sym_const_statement,
+    STATE(113), 2,
+      sym_integer_type,
+      sym_float_type,
+    ACTIONS(169), 3,
+      anon_sym_sequence,
+      anon_sym_FrozenArray,
+      anon_sym_ObservableArray,
+    ACTIONS(190), 3,
+      anon_sym_ByteString,
+      anon_sym_DOMString,
+      anon_sym_USVString,
+    STATE(200), 3,
+      sym__single_type,
+      sym_distinguishable_type,
+      sym_promise_type,
+    ACTIONS(163), 4,
+      anon_sym_undefined,
+      anon_sym_object,
+      anon_sym_symbol,
+      sym_identifier,
+    ACTIONS(172), 4,
+      anon_sym_boolean,
+      anon_sym_byte,
+      anon_sym_octet,
+      anon_sym_bigint,
+    STATE(112), 4,
+      sym_primitive_type,
+      sym_string_type,
+      sym_record_type,
+      sym_buffer_related_type,
+    ACTIONS(199), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -9287,7 +9244,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(107), 1,
       sym_type,
-    STATE(120), 1,
+    STATE(124), 1,
       sym_union_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9298,10 +9255,10 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(11), 2,
       aux_sym__namespace_members,
       sym_namespace_member,
-    STATE(52), 2,
+    STATE(53), 2,
       sym_regular_operation,
       sym_const_statement,
-    STATE(123), 2,
+    STATE(113), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(128), 3,
@@ -9312,7 +9269,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(148), 3,
+    STATE(200), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9326,7 +9283,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(122), 4,
+    STATE(112), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -9372,7 +9329,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(107), 1,
       sym_type,
-    STATE(120), 1,
+    STATE(124), 1,
       sym_union_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9380,13 +9337,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(140), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(9), 2,
+    STATE(11), 2,
       aux_sym__namespace_members,
       sym_namespace_member,
-    STATE(52), 2,
+    STATE(53), 2,
       sym_regular_operation,
       sym_const_statement,
-    STATE(123), 2,
+    STATE(113), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(128), 3,
@@ -9397,7 +9354,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(148), 3,
+    STATE(200), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9411,7 +9368,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(122), 4,
+    STATE(112), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -9439,12 +9396,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_async,
     ACTIONS(31), 1,
       anon_sym_any,
-    ACTIONS(37), 1,
-      anon_sym_unsigned,
     ACTIONS(39), 1,
       anon_sym_short,
-    ACTIONS(41), 1,
-      anon_sym_long,
     ACTIONS(43), 1,
       anon_sym_restricted,
     ACTIONS(49), 1,
@@ -9453,13 +9406,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_record,
     ACTIONS(206), 1,
       anon_sym_LBRACK,
-    STATE(37), 1,
+    ACTIONS(208), 1,
+      anon_sym_unsigned,
+    ACTIONS(210), 1,
+      anon_sym_long,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(277), 1,
+    STATE(258), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9467,7 +9424,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -9478,7 +9435,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9492,7 +9449,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -9534,13 +9491,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(288), 1,
+    STATE(252), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9548,7 +9505,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -9559,7 +9516,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9573,7 +9530,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -9595,71 +9552,71 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [1565] = 24,
-    ACTIONS(19), 1,
-      anon_sym_LPAREN,
-    ACTIONS(21), 1,
-      anon_sym_async,
-    ACTIONS(31), 1,
-      anon_sym_any,
-    ACTIONS(39), 1,
-      anon_sym_short,
-    ACTIONS(43), 1,
-      anon_sym_restricted,
-    ACTIONS(49), 1,
-      anon_sym_promise,
-    ACTIONS(51), 1,
-      anon_sym_record,
     ACTIONS(206), 1,
       anon_sym_LBRACK,
-    ACTIONS(208), 1,
+    ACTIONS(212), 1,
+      anon_sym_LPAREN,
+    ACTIONS(214), 1,
+      anon_sym_async,
+    ACTIONS(218), 1,
+      anon_sym_any,
+    ACTIONS(224), 1,
       anon_sym_unsigned,
-    ACTIONS(210), 1,
+    ACTIONS(226), 1,
+      anon_sym_short,
+    ACTIONS(228), 1,
       anon_sym_long,
-    STATE(38), 1,
+    ACTIONS(230), 1,
+      anon_sym_restricted,
+    ACTIONS(236), 1,
+      anon_sym_promise,
+    ACTIONS(238), 1,
+      anon_sym_record,
+    STATE(37), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
-      sym_union_type,
-    STATE(191), 1,
-      sym_type,
-    STATE(290), 1,
+    STATE(63), 1,
       sym_type_with_extended_attributes,
+    STATE(64), 1,
+      sym_union_type,
+    STATE(85), 1,
+      sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(45), 2,
+    ACTIONS(232), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(66), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(33), 3,
+    ACTIONS(220), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(47), 3,
+    ACTIONS(234), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(78), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(29), 4,
+    ACTIONS(216), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(35), 4,
+    ACTIONS(222), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(65), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(53), 15,
+    ACTIONS(240), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -9696,13 +9653,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(289), 1,
+    STATE(257), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9710,7 +9667,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -9721,7 +9678,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9735,7 +9692,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -9761,57 +9718,57 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(214), 1,
       anon_sym_async,
-    ACTIONS(216), 1,
-      anon_sym_optional,
-    ACTIONS(220), 1,
+    ACTIONS(218), 1,
       anon_sym_any,
-    ACTIONS(226), 1,
+    ACTIONS(224), 1,
       anon_sym_unsigned,
-    ACTIONS(228), 1,
+    ACTIONS(226), 1,
       anon_sym_short,
-    ACTIONS(230), 1,
+    ACTIONS(228), 1,
       anon_sym_long,
-    ACTIONS(232), 1,
+    ACTIONS(230), 1,
       anon_sym_restricted,
-    ACTIONS(238), 1,
+    ACTIONS(236), 1,
       anon_sym_promise,
-    ACTIONS(240), 1,
+    ACTIONS(238), 1,
       anon_sym_record,
+    ACTIONS(242), 1,
+      anon_sym_optional,
     STATE(59), 1,
       sym_type,
-    STATE(69), 1,
+    STATE(64), 1,
       sym_union_type,
-    STATE(182), 1,
+    STATE(198), 1,
       sym_argument,
-    STATE(252), 1,
+    STATE(298), 1,
       sym_argument_list,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(234), 2,
+    ACTIONS(232), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(64), 2,
+    STATE(66), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(222), 3,
+    ACTIONS(220), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(236), 3,
+    ACTIONS(234), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(80), 3,
+    STATE(78), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(218), 4,
+    ACTIONS(216), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(224), 4,
+    ACTIONS(222), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
@@ -9821,7 +9778,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(242), 15,
+    ACTIONS(240), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -9838,71 +9795,71 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [1880] = 24,
-    ACTIONS(19), 1,
+    ACTIONS(212), 1,
       anon_sym_LPAREN,
-    ACTIONS(21), 1,
+    ACTIONS(214), 1,
       anon_sym_async,
-    ACTIONS(31), 1,
+    ACTIONS(218), 1,
       anon_sym_any,
-    ACTIONS(37), 1,
+    ACTIONS(224), 1,
       anon_sym_unsigned,
-    ACTIONS(39), 1,
+    ACTIONS(226), 1,
       anon_sym_short,
-    ACTIONS(41), 1,
+    ACTIONS(228), 1,
       anon_sym_long,
-    ACTIONS(43), 1,
+    ACTIONS(230), 1,
       anon_sym_restricted,
-    ACTIONS(49), 1,
+    ACTIONS(236), 1,
       anon_sym_promise,
-    ACTIONS(51), 1,
+    ACTIONS(238), 1,
       anon_sym_record,
-    ACTIONS(206), 1,
-      anon_sym_LBRACK,
-    STATE(37), 1,
-      sym_extended_attribute_list,
-    STATE(117), 1,
-      sym_union_type,
-    STATE(191), 1,
+    ACTIONS(242), 1,
+      anon_sym_optional,
+    STATE(59), 1,
       sym_type,
-    STATE(316), 1,
-      sym_type_with_extended_attributes,
+    STATE(64), 1,
+      sym_union_type,
+    STATE(198), 1,
+      sym_argument,
+    STATE(275), 1,
+      sym_argument_list,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(45), 2,
+    ACTIONS(232), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(66), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(33), 3,
+    ACTIONS(220), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(47), 3,
+    ACTIONS(234), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(78), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(29), 4,
+    ACTIONS(216), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(35), 4,
+    ACTIONS(222), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(65), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(53), 15,
+    ACTIONS(240), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -9925,8 +9882,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_async,
     ACTIONS(31), 1,
       anon_sym_any,
+    ACTIONS(37), 1,
+      anon_sym_unsigned,
     ACTIONS(39), 1,
       anon_sym_short,
+    ACTIONS(41), 1,
+      anon_sym_long,
     ACTIONS(43), 1,
       anon_sym_restricted,
     ACTIONS(49), 1,
@@ -9935,17 +9896,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_record,
     ACTIONS(206), 1,
       anon_sym_LBRACK,
-    ACTIONS(208), 1,
-      anon_sym_unsigned,
-    ACTIONS(210), 1,
-      anon_sym_long,
-    STATE(38), 1,
+    STATE(35), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(266), 1,
+    STATE(292), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -9953,7 +9910,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -9964,7 +9921,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -9978,7 +9935,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10000,71 +9957,71 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [2090] = 24,
+    ACTIONS(19), 1,
+      anon_sym_LPAREN,
+    ACTIONS(21), 1,
+      anon_sym_async,
+    ACTIONS(31), 1,
+      anon_sym_any,
+    ACTIONS(37), 1,
+      anon_sym_unsigned,
+    ACTIONS(39), 1,
+      anon_sym_short,
+    ACTIONS(41), 1,
+      anon_sym_long,
+    ACTIONS(43), 1,
+      anon_sym_restricted,
+    ACTIONS(49), 1,
+      anon_sym_promise,
+    ACTIONS(51), 1,
+      anon_sym_record,
     ACTIONS(206), 1,
       anon_sym_LBRACK,
-    ACTIONS(212), 1,
-      anon_sym_LPAREN,
-    ACTIONS(214), 1,
-      anon_sym_async,
-    ACTIONS(220), 1,
-      anon_sym_any,
-    ACTIONS(226), 1,
-      anon_sym_unsigned,
-    ACTIONS(228), 1,
-      anon_sym_short,
-    ACTIONS(230), 1,
-      anon_sym_long,
-    ACTIONS(232), 1,
-      anon_sym_restricted,
-    ACTIONS(238), 1,
-      anon_sym_promise,
-    ACTIONS(240), 1,
-      anon_sym_record,
-    STATE(39), 1,
+    STATE(35), 1,
       sym_extended_attribute_list,
-    STATE(66), 1,
-      sym_type_with_extended_attributes,
-    STATE(69), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(85), 1,
+    STATE(159), 1,
       sym_type,
+    STATE(253), 1,
+      sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(234), 2,
+    ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(64), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(222), 3,
+    ACTIONS(33), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(236), 3,
+    ACTIONS(47), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(80), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(218), 4,
+    ACTIONS(29), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(224), 4,
+    ACTIONS(35), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(65), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(242), 15,
+    ACTIONS(53), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -10085,57 +10042,57 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(214), 1,
       anon_sym_async,
-    ACTIONS(216), 1,
-      anon_sym_optional,
-    ACTIONS(220), 1,
+    ACTIONS(218), 1,
       anon_sym_any,
-    ACTIONS(226), 1,
+    ACTIONS(224), 1,
       anon_sym_unsigned,
-    ACTIONS(228), 1,
+    ACTIONS(226), 1,
       anon_sym_short,
-    ACTIONS(230), 1,
+    ACTIONS(228), 1,
       anon_sym_long,
-    ACTIONS(232), 1,
+    ACTIONS(230), 1,
       anon_sym_restricted,
-    ACTIONS(238), 1,
+    ACTIONS(236), 1,
       anon_sym_promise,
-    ACTIONS(240), 1,
+    ACTIONS(238), 1,
       anon_sym_record,
+    ACTIONS(242), 1,
+      anon_sym_optional,
     STATE(59), 1,
       sym_type,
-    STATE(69), 1,
+    STATE(64), 1,
       sym_union_type,
-    STATE(182), 1,
+    STATE(198), 1,
       sym_argument,
-    STATE(317), 1,
+    STATE(243), 1,
       sym_argument_list,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(234), 2,
+    ACTIONS(232), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(64), 2,
+    STATE(66), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(222), 3,
+    ACTIONS(220), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(236), 3,
+    ACTIONS(234), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(80), 3,
+    STATE(78), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(218), 4,
+    ACTIONS(216), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(224), 4,
+    ACTIONS(222), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
@@ -10145,7 +10102,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(242), 15,
+    ACTIONS(240), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -10162,71 +10119,71 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [2300] = 24,
-    ACTIONS(212), 1,
+    ACTIONS(19), 1,
       anon_sym_LPAREN,
-    ACTIONS(214), 1,
+    ACTIONS(21), 1,
       anon_sym_async,
-    ACTIONS(216), 1,
-      anon_sym_optional,
-    ACTIONS(220), 1,
+    ACTIONS(31), 1,
       anon_sym_any,
-    ACTIONS(226), 1,
-      anon_sym_unsigned,
-    ACTIONS(228), 1,
+    ACTIONS(39), 1,
       anon_sym_short,
-    ACTIONS(230), 1,
-      anon_sym_long,
-    ACTIONS(232), 1,
+    ACTIONS(43), 1,
       anon_sym_restricted,
-    ACTIONS(238), 1,
+    ACTIONS(49), 1,
       anon_sym_promise,
-    ACTIONS(240), 1,
+    ACTIONS(51), 1,
       anon_sym_record,
-    STATE(59), 1,
-      sym_type,
-    STATE(69), 1,
+    ACTIONS(206), 1,
+      anon_sym_LBRACK,
+    ACTIONS(208), 1,
+      anon_sym_unsigned,
+    ACTIONS(210), 1,
+      anon_sym_long,
+    STATE(39), 1,
+      sym_extended_attribute_list,
+    STATE(115), 1,
       sym_union_type,
-    STATE(182), 1,
-      sym_argument,
-    STATE(235), 1,
-      sym_argument_list,
+    STATE(159), 1,
+      sym_type,
+    STATE(286), 1,
+      sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(234), 2,
+    ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(64), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(222), 3,
+    ACTIONS(33), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(236), 3,
+    ACTIONS(47), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(80), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(218), 4,
+    ACTIONS(29), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(224), 4,
+    ACTIONS(35), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(65), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(242), 15,
+    ACTIONS(53), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -10263,13 +10220,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(275), 1,
+    STATE(284), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10277,7 +10234,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10288,7 +10245,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10302,7 +10259,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10344,13 +10301,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(272), 1,
+    STATE(270), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10358,7 +10315,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10369,7 +10326,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10383,7 +10340,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10425,13 +10382,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(274), 1,
+    STATE(277), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10439,7 +10396,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10450,7 +10407,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10464,7 +10421,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10506,13 +10463,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(286), 1,
+    STATE(272), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10520,7 +10477,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10531,7 +10488,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10545,7 +10502,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10587,13 +10544,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(279), 1,
+    STATE(273), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10601,7 +10558,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10612,7 +10569,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10626,7 +10583,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10668,13 +10625,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(281), 1,
+    STATE(285), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10682,7 +10639,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10693,7 +10650,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10707,7 +10664,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10749,13 +10706,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(282), 1,
+    STATE(323), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10763,7 +10720,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10774,7 +10731,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10788,7 +10745,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10830,13 +10787,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_extended_attribute_list,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(191), 1,
+    STATE(159), 1,
       sym_type,
-    STATE(287), 1,
+    STATE(279), 1,
       sym_type_with_extended_attributes,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10844,7 +10801,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10855,7 +10812,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10869,7 +10826,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10913,9 +10870,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_record,
     STATE(48), 1,
       sym__dictionary_member_rest,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(254), 1,
+    STATE(266), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -10923,7 +10880,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -10934,7 +10891,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -10948,7 +10905,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -10974,55 +10931,55 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LPAREN,
     ACTIONS(214), 1,
       anon_sym_async,
-    ACTIONS(216), 1,
-      anon_sym_optional,
-    ACTIONS(220), 1,
+    ACTIONS(218), 1,
       anon_sym_any,
-    ACTIONS(226), 1,
+    ACTIONS(224), 1,
       anon_sym_unsigned,
-    ACTIONS(228), 1,
+    ACTIONS(226), 1,
       anon_sym_short,
-    ACTIONS(230), 1,
+    ACTIONS(228), 1,
       anon_sym_long,
-    ACTIONS(232), 1,
+    ACTIONS(230), 1,
       anon_sym_restricted,
-    ACTIONS(238), 1,
+    ACTIONS(236), 1,
       anon_sym_promise,
-    ACTIONS(240), 1,
+    ACTIONS(238), 1,
       anon_sym_record,
+    ACTIONS(242), 1,
+      anon_sym_optional,
     STATE(59), 1,
       sym_type,
-    STATE(69), 1,
+    STATE(64), 1,
       sym_union_type,
-    STATE(202), 1,
+    STATE(209), 1,
       sym_argument,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(234), 2,
+    ACTIONS(232), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(64), 2,
+    STATE(66), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(222), 3,
+    ACTIONS(220), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(236), 3,
+    ACTIONS(234), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(80), 3,
+    STATE(78), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(218), 4,
+    ACTIONS(216), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(224), 4,
+    ACTIONS(222), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
@@ -11032,7 +10989,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(242), 15,
+    ACTIONS(240), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -11067,9 +11024,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(280), 1,
+    STATE(265), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -11077,7 +11034,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -11088,7 +11045,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -11102,7 +11059,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11130,21 +11087,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_async,
     ACTIONS(31), 1,
       anon_sym_any,
+    ACTIONS(37), 1,
+      anon_sym_unsigned,
     ACTIONS(39), 1,
       anon_sym_short,
+    ACTIONS(41), 1,
+      anon_sym_long,
     ACTIONS(43), 1,
       anon_sym_restricted,
     ACTIONS(49), 1,
       anon_sym_promise,
     ACTIONS(51), 1,
       anon_sym_record,
-    ACTIONS(208), 1,
-      anon_sym_unsigned,
-    ACTIONS(210), 1,
-      anon_sym_long,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(295), 1,
+    STATE(199), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -11152,7 +11109,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -11163,7 +11120,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -11177,7 +11134,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11217,9 +11174,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(273), 1,
+    STATE(278), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -11227,7 +11184,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -11238,7 +11195,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -11252,7 +11209,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11274,65 +11231,65 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [3737] = 21,
-    ACTIONS(19), 1,
+    ACTIONS(212), 1,
       anon_sym_LPAREN,
-    ACTIONS(21), 1,
+    ACTIONS(214), 1,
       anon_sym_async,
-    ACTIONS(31), 1,
+    ACTIONS(218), 1,
       anon_sym_any,
-    ACTIONS(37), 1,
+    ACTIONS(224), 1,
       anon_sym_unsigned,
-    ACTIONS(39), 1,
+    ACTIONS(226), 1,
       anon_sym_short,
-    ACTIONS(41), 1,
+    ACTIONS(228), 1,
       anon_sym_long,
-    ACTIONS(43), 1,
+    ACTIONS(230), 1,
       anon_sym_restricted,
-    ACTIONS(49), 1,
+    ACTIONS(236), 1,
       anon_sym_promise,
-    ACTIONS(51), 1,
+    ACTIONS(238), 1,
       anon_sym_record,
-    STATE(117), 1,
+    STATE(64), 1,
       sym_union_type,
-    STATE(160), 1,
+    STATE(84), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(45), 2,
+    ACTIONS(232), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(66), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(33), 3,
+    ACTIONS(220), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(47), 3,
+    ACTIONS(234), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(78), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(29), 4,
+    ACTIONS(216), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(35), 4,
+    ACTIONS(222), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(65), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(53), 15,
+    ACTIONS(240), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -11367,9 +11324,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_unsigned,
     ACTIONS(210), 1,
       anon_sym_long,
-    STATE(117), 1,
+    STATE(115), 1,
       sym_union_type,
-    STATE(160), 1,
+    STATE(271), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -11377,7 +11334,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
     ACTIONS(33), 3,
@@ -11388,7 +11345,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(167), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
@@ -11402,7 +11359,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(112), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11424,65 +11381,65 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
   [3929] = 21,
-    ACTIONS(212), 1,
+    ACTIONS(19), 1,
       anon_sym_LPAREN,
-    ACTIONS(214), 1,
+    ACTIONS(21), 1,
       anon_sym_async,
-    ACTIONS(220), 1,
+    ACTIONS(31), 1,
       anon_sym_any,
-    ACTIONS(226), 1,
-      anon_sym_unsigned,
-    ACTIONS(228), 1,
+    ACTIONS(39), 1,
       anon_sym_short,
-    ACTIONS(230), 1,
-      anon_sym_long,
-    ACTIONS(232), 1,
+    ACTIONS(43), 1,
       anon_sym_restricted,
-    ACTIONS(238), 1,
+    ACTIONS(49), 1,
       anon_sym_promise,
-    ACTIONS(240), 1,
+    ACTIONS(51), 1,
       anon_sym_record,
-    STATE(69), 1,
+    ACTIONS(208), 1,
+      anon_sym_unsigned,
+    ACTIONS(210), 1,
+      anon_sym_long,
+    STATE(115), 1,
       sym_union_type,
-    STATE(84), 1,
+    STATE(199), 1,
       sym_type,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(234), 2,
+    ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(64), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
-    ACTIONS(222), 3,
+    ACTIONS(33), 3,
       anon_sym_sequence,
       anon_sym_FrozenArray,
       anon_sym_ObservableArray,
-    ACTIONS(236), 3,
+    ACTIONS(47), 3,
       anon_sym_ByteString,
       anon_sym_DOMString,
       anon_sym_USVString,
-    STATE(80), 3,
+    STATE(161), 3,
       sym__single_type,
       sym_distinguishable_type,
       sym_promise_type,
-    ACTIONS(218), 4,
+    ACTIONS(29), 4,
       anon_sym_undefined,
       anon_sym_object,
       anon_sym_symbol,
       sym_identifier,
-    ACTIONS(224), 4,
+    ACTIONS(35), 4,
       anon_sym_boolean,
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(65), 4,
+    STATE(126), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
       sym_buffer_related_type,
-    ACTIONS(242), 15,
+    ACTIONS(53), 15,
       anon_sym_ArrayBuffer,
       anon_sym_SharedArrayBuffer,
       anon_sym_DataView,
@@ -11513,20 +11470,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_restricted,
     ACTIONS(266), 1,
       anon_sym_record,
-    STATE(301), 1,
-      sym_union_member_type,
-    STATE(325), 1,
+    STATE(237), 1,
       sym_union_or_expression,
+    STATE(239), 1,
+      sym_union_member_type,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(262), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(184), 2,
+    STATE(165), 2,
       sym_integer_type,
       sym_float_type,
-    STATE(223), 2,
+    STATE(225), 2,
       sym_union_type,
       sym_distinguishable_type,
     ACTIONS(250), 3,
@@ -11547,7 +11504,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(181), 4,
+    STATE(164), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11583,20 +11540,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_restricted,
     ACTIONS(266), 1,
       anon_sym_record,
-    STATE(269), 1,
-      sym_union_or_expression,
-    STATE(301), 1,
+    STATE(239), 1,
       sym_union_member_type,
+    STATE(276), 1,
+      sym_union_or_expression,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(262), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(184), 2,
+    STATE(165), 2,
       sym_integer_type,
       sym_float_type,
-    STATE(223), 2,
+    STATE(225), 2,
       sym_union_type,
       sym_distinguishable_type,
     ACTIONS(250), 3,
@@ -11617,7 +11574,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(181), 4,
+    STATE(164), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11653,9 +11610,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_restricted,
     ACTIONS(266), 1,
       anon_sym_record,
-    STATE(222), 1,
+    STATE(239), 1,
       sym_union_member_type,
-    STATE(283), 1,
+    STATE(267), 1,
       sym_union_or_expression,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -11663,10 +11620,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(262), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(184), 2,
+    STATE(165), 2,
       sym_integer_type,
       sym_float_type,
-    STATE(223), 2,
+    STATE(225), 2,
       sym_union_type,
       sym_distinguishable_type,
     ACTIONS(250), 3,
@@ -11687,7 +11644,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(181), 4,
+    STATE(164), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11723,20 +11680,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_restricted,
     ACTIONS(266), 1,
       anon_sym_record,
-    STATE(300), 1,
-      sym_union_or_expression,
-    STATE(301), 1,
+    STATE(239), 1,
       sym_union_member_type,
+    STATE(283), 1,
+      sym_union_or_expression,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(262), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(184), 2,
+    STATE(165), 2,
       sym_integer_type,
       sym_float_type,
-    STATE(223), 2,
+    STATE(225), 2,
       sym_union_type,
       sym_distinguishable_type,
     ACTIONS(250), 3,
@@ -11757,7 +11714,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(181), 4,
+    STATE(164), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -11793,20 +11750,20 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_restricted,
     ACTIONS(266), 1,
       anon_sym_record,
-    STATE(285), 1,
-      sym_union_or_expression,
-    STATE(301), 1,
+    STATE(206), 1,
       sym_union_member_type,
+    STATE(250), 1,
+      sym_union_or_expression,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(262), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(184), 2,
+    STATE(165), 2,
       sym_integer_type,
       sym_float_type,
-    STATE(223), 2,
+    STATE(225), 2,
       sym_union_type,
       sym_distinguishable_type,
     ACTIONS(250), 3,
@@ -11827,7 +11784,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-    STATE(181), 4,
+    STATE(164), 4,
       sym_primitive_type,
       sym_string_type,
       sym_record_type,
@@ -12428,52 +12385,6 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float64Array,
       sym_identifier,
   [5085] = 3,
-    ACTIONS(314), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(316), 39,
-      anon_sym_async,
-      anon_sym_undefined,
-      anon_sym_any,
-      anon_sym_sequence,
-      anon_sym_object,
-      anon_sym_symbol,
-      anon_sym_FrozenArray,
-      anon_sym_ObservableArray,
-      anon_sym_boolean,
-      anon_sym_byte,
-      anon_sym_octet,
-      anon_sym_bigint,
-      anon_sym_unsigned,
-      anon_sym_short,
-      anon_sym_long,
-      anon_sym_restricted,
-      anon_sym_float,
-      anon_sym_double,
-      anon_sym_ByteString,
-      anon_sym_DOMString,
-      anon_sym_USVString,
-      anon_sym_promise,
-      anon_sym_record,
-      anon_sym_ArrayBuffer,
-      anon_sym_SharedArrayBuffer,
-      anon_sym_DataView,
-      anon_sym_Int8Array,
-      anon_sym_Int16Array,
-      anon_sym_Int32Array,
-      anon_sym_Uint8Array,
-      anon_sym_Uint16Array,
-      anon_sym_Uint32Array,
-      anon_sym_Uint8ClampedArray,
-      anon_sym_BigInt64Array,
-      anon_sym_BigUint64Array,
-      anon_sym_Float16Array,
-      anon_sym_Float32Array,
-      anon_sym_Float64Array,
-      sym_identifier,
-  [5134] = 3,
     ACTIONS(310), 1,
       anon_sym_LPAREN,
     ACTIONS(3), 2,
@@ -12519,18 +12430,63 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_Float32Array,
       anon_sym_Float64Array,
       sym_identifier,
-  [5183] = 6,
+  [5134] = 3,
+    ACTIONS(314), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(316), 39,
+      anon_sym_async,
+      anon_sym_undefined,
+      anon_sym_any,
+      anon_sym_sequence,
+      anon_sym_object,
+      anon_sym_symbol,
+      anon_sym_FrozenArray,
+      anon_sym_ObservableArray,
+      anon_sym_boolean,
+      anon_sym_byte,
+      anon_sym_octet,
+      anon_sym_bigint,
+      anon_sym_unsigned,
+      anon_sym_short,
+      anon_sym_long,
+      anon_sym_restricted,
+      anon_sym_float,
+      anon_sym_double,
+      anon_sym_ByteString,
+      anon_sym_DOMString,
+      anon_sym_USVString,
+      anon_sym_promise,
+      anon_sym_record,
+      anon_sym_ArrayBuffer,
+      anon_sym_SharedArrayBuffer,
+      anon_sym_DataView,
+      anon_sym_Int8Array,
+      anon_sym_Int16Array,
+      anon_sym_Int32Array,
+      anon_sym_Uint8Array,
+      anon_sym_Uint16Array,
+      anon_sym_Uint32Array,
+      anon_sym_Uint8ClampedArray,
+      anon_sym_BigInt64Array,
+      anon_sym_BigUint64Array,
+      anon_sym_Float16Array,
+      anon_sym_Float32Array,
+      anon_sym_Float64Array,
+      sym_identifier,
+  [5183] = 5,
     ACTIONS(320), 1,
       sym_ellipsis,
     ACTIONS(322), 1,
       sym_identifier,
-    STATE(149), 1,
-      sym_argument_name_keyword,
-    STATE(220), 1,
-      sym_argument_name,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
+    STATE(230), 2,
+      sym_argument_name_keyword,
+      sym__argument_name,
     ACTIONS(318), 25,
       anon_sym_includes,
       anon_sym_async,
@@ -12557,7 +12513,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_stringifier,
       anon_sym_typedef,
       anon_sym_unrestricted,
-  [5227] = 4,
+  [5225] = 4,
     ACTIONS(328), 1,
       anon_sym_long,
     ACTIONS(3), 2,
@@ -12593,7 +12549,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5267] = 4,
+  [5265] = 4,
     ACTIONS(334), 1,
       anon_sym_long,
     ACTIONS(3), 2,
@@ -12629,7 +12585,181 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5307] = 3,
+  [5305] = 4,
+    ACTIONS(336), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    STATE(226), 2,
+      sym_argument_name_keyword,
+      sym__argument_name,
+    ACTIONS(318), 25,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+  [5344] = 4,
+    ACTIONS(338), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    STATE(138), 2,
+      sym_argument_name_keyword,
+      sym__argument_name,
+    ACTIONS(318), 25,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+  [5383] = 4,
+    ACTIONS(342), 1,
+      sym_ellipsis,
+    ACTIONS(344), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(340), 26,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+      sym_identifier,
+  [5422] = 4,
+    ACTIONS(348), 1,
+      sym_ellipsis,
+    ACTIONS(350), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(346), 26,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+      sym_identifier,
+  [5461] = 3,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(354), 2,
+      sym_ellipsis,
+      anon_sym_QMARK,
+    ACTIONS(352), 26,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+      sym_identifier,
+  [5498] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -12663,182 +12793,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5344] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(338), 2,
-      sym_ellipsis,
-      anon_sym_QMARK,
-    ACTIONS(336), 26,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-      sym_identifier,
-  [5381] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(342), 2,
-      sym_ellipsis,
-      anon_sym_QMARK,
-    ACTIONS(340), 26,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-      sym_identifier,
-  [5418] = 4,
-    ACTIONS(346), 1,
-      sym_ellipsis,
-    ACTIONS(348), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(344), 26,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-      sym_identifier,
-  [5457] = 5,
-    ACTIONS(322), 1,
-      sym_identifier,
-    STATE(116), 1,
-      sym_argument_name,
-    STATE(149), 1,
-      sym_argument_name_keyword,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(318), 25,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-  [5498] = 5,
-    ACTIONS(322), 1,
-      sym_identifier,
-    STATE(149), 1,
-      sym_argument_name_keyword,
-    STATE(205), 1,
-      sym_argument_name,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(318), 25,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-  [5539] = 3,
+  [5535] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -12872,42 +12827,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5576] = 4,
-    ACTIONS(352), 1,
-      sym_ellipsis,
-    ACTIONS(354), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(350), 26,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-      sym_identifier,
-  [5615] = 3,
+  [5572] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -12941,7 +12861,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5652] = 3,
+  [5609] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -12975,14 +12895,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5689] = 4,
-    ACTIONS(366), 1,
-      sym_ellipsis,
-    ACTIONS(368), 1,
-      anon_sym_QMARK,
+  [5646] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
+    ACTIONS(366), 2,
+      sym_ellipsis,
+      anon_sym_QMARK,
     ACTIONS(364), 26,
       anon_sym_includes,
       anon_sym_async,
@@ -13010,14 +12929,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5728] = 3,
+  [5683] = 4,
+    ACTIONS(370), 1,
+      sym_ellipsis,
+    ACTIONS(372), 1,
+      anon_sym_QMARK,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(372), 2,
-      sym_ellipsis,
-      anon_sym_QMARK,
-    ACTIONS(370), 26,
+    ACTIONS(368), 26,
       anon_sym_includes,
       anon_sym_async,
       anon_sym_attribute,
@@ -13044,13 +12964,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5765] = 3,
+  [5722] = 4,
+    ACTIONS(376), 1,
+      sym_ellipsis,
+    ACTIONS(378), 1,
+      anon_sym_QMARK,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(376), 2,
-      sym_ellipsis,
-      anon_sym_QMARK,
     ACTIONS(374), 26,
       anon_sym_includes,
       anon_sym_async,
@@ -13078,14 +12999,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5802] = 3,
+  [5761] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(380), 2,
+    ACTIONS(382), 2,
       sym_ellipsis,
       anon_sym_QMARK,
-    ACTIONS(378), 26,
+    ACTIONS(380), 26,
       anon_sym_includes,
       anon_sym_async,
       anon_sym_attribute,
@@ -13112,14 +13033,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5839] = 3,
+  [5798] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(384), 2,
+    ACTIONS(386), 2,
       sym_ellipsis,
       anon_sym_QMARK,
-    ACTIONS(382), 26,
+    ACTIONS(384), 26,
       anon_sym_includes,
       anon_sym_async,
       anon_sym_attribute,
@@ -13146,15 +13067,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5876] = 4,
-    ACTIONS(388), 1,
-      sym_ellipsis,
-    ACTIONS(390), 1,
-      anon_sym_QMARK,
+  [5835] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(386), 26,
+    ACTIONS(390), 2,
+      sym_ellipsis,
+      anon_sym_QMARK,
+    ACTIONS(388), 26,
       anon_sym_includes,
       anon_sym_async,
       anon_sym_attribute,
@@ -13181,12 +13101,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5915] = 3,
-    ACTIONS(394), 1,
-      sym_ellipsis,
+  [5872] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
+    ACTIONS(394), 2,
+      sym_ellipsis,
+      anon_sym_QMARK,
     ACTIONS(392), 26,
       anon_sym_includes,
       anon_sym_async,
@@ -13214,7 +13135,40 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5951] = 3,
+  [5909] = 3,
+    ACTIONS(342), 1,
+      sym_ellipsis,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(340), 26,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+      sym_identifier,
+  [5945] = 3,
     ACTIONS(398), 1,
       sym_ellipsis,
     ACTIONS(3), 2,
@@ -13247,40 +13201,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [5987] = 3,
-    ACTIONS(352), 1,
-      sym_ellipsis,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(350), 26,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-      sym_identifier,
-  [6023] = 3,
+  [5981] = 3,
     ACTIONS(402), 1,
       sym_ellipsis,
     ACTIONS(3), 2,
@@ -13313,7 +13234,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [6059] = 3,
+  [6017] = 3,
     ACTIONS(406), 1,
       sym_ellipsis,
     ACTIONS(3), 2,
@@ -13346,40 +13267,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [6095] = 3,
-    ACTIONS(388), 1,
+  [6053] = 3,
+    ACTIONS(410), 1,
       sym_ellipsis,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(386), 26,
-      anon_sym_includes,
-      anon_sym_async,
-      anon_sym_attribute,
-      anon_sym_callback,
-      anon_sym_const,
-      anon_sym_constructor,
-      anon_sym_deleter,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_getter,
-      anon_sym_inherit,
-      anon_sym_interface,
-      anon_sym_iterable,
-      anon_sym_maplike,
-      anon_sym_mixin,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_readonly,
-      anon_sym_required,
-      anon_sym_setlike,
-      anon_sym_setter,
-      anon_sym_static,
-      anon_sym_stringifier,
-      anon_sym_typedef,
-      anon_sym_unrestricted,
-      sym_identifier,
-  [6131] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -13410,11 +13300,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [6164] = 2,
+  [6089] = 3,
+    ACTIONS(376), 1,
+      sym_ellipsis,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(410), 26,
+    ACTIONS(374), 26,
       anon_sym_includes,
       anon_sym_async,
       anon_sym_attribute,
@@ -13441,7 +13333,98 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
       anon_sym_unrestricted,
       sym_identifier,
-  [6197] = 10,
+  [6125] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(412), 26,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+      sym_identifier,
+  [6158] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(414), 26,
+      anon_sym_includes,
+      anon_sym_async,
+      anon_sym_attribute,
+      anon_sym_callback,
+      anon_sym_const,
+      anon_sym_constructor,
+      anon_sym_deleter,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_getter,
+      anon_sym_inherit,
+      anon_sym_interface,
+      anon_sym_iterable,
+      anon_sym_maplike,
+      anon_sym_mixin,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_readonly,
+      anon_sym_required,
+      anon_sym_setlike,
+      anon_sym_setter,
+      anon_sym_static,
+      anon_sym_stringifier,
+      anon_sym_typedef,
+      anon_sym_unrestricted,
+      sym_identifier,
+  [6191] = 9,
+    ACTIONS(416), 1,
+      anon_sym_LBRACE,
+    ACTIONS(418), 1,
+      anon_sym_LBRACK,
+    ACTIONS(426), 1,
+      sym__integer,
+    STATE(152), 1,
+      sym_default_value,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(422), 2,
+      anon_sym_true,
+      anon_sym_false,
+    ACTIONS(420), 3,
+      anon_sym_null,
+      anon_sym_undefined,
+      sym_string,
+    ACTIONS(424), 4,
+      anon_sym_DASHInfinity,
+      anon_sym_Infinity,
+      anon_sym_NaN,
+      sym__decimal,
+    STATE(149), 4,
+      sym__const_value,
+      sym_integer_literal,
+      sym_boolean_literal,
+      sym_float_literal,
+  [6229] = 10,
     ACTIONS(37), 1,
       anon_sym_unsigned,
     ACTIONS(39), 1,
@@ -13450,7 +13433,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_long,
     ACTIONS(43), 1,
       anon_sym_restricted,
-    ACTIONS(412), 1,
+    ACTIONS(428), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -13458,10 +13441,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(45), 2,
       anon_sym_float,
       anon_sym_double,
-    STATE(113), 2,
+    STATE(136), 2,
       sym_integer_type,
       sym_float_type,
-    STATE(248), 2,
+    STATE(236), 2,
       sym__const_type,
       sym_primitive_type,
     ACTIONS(35), 4,
@@ -13469,7 +13452,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_byte,
       anon_sym_octet,
       anon_sym_bigint,
-  [6235] = 10,
+  [6267] = 10,
     ACTIONS(7), 1,
       anon_sym_dictionary,
     ACTIONS(9), 1,
@@ -13482,106 +13465,81 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_typedef,
     ACTIONS(17), 1,
       sym_identifier,
-    ACTIONS(414), 1,
+    ACTIONS(430), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    STATE(88), 2,
+    STATE(89), 2,
       sym__definition,
       aux_sym_source_file_repeat1,
-    STATE(91), 5,
+    STATE(92), 5,
       sym_namespace_statement,
       sym_dictionary_statement,
       sym_enum_statement,
       sym_includes_statement,
       sym_typedef_statement,
-  [6272] = 10,
-    ACTIONS(416), 1,
+  [6304] = 10,
+    ACTIONS(432), 1,
       ts_builtin_sym_end,
-    ACTIONS(418), 1,
+    ACTIONS(434), 1,
       anon_sym_dictionary,
-    ACTIONS(421), 1,
+    ACTIONS(437), 1,
       anon_sym_enum,
-    ACTIONS(424), 1,
+    ACTIONS(440), 1,
       anon_sym_namespace,
-    ACTIONS(427), 1,
+    ACTIONS(443), 1,
       anon_sym_partial,
-    ACTIONS(430), 1,
+    ACTIONS(446), 1,
       anon_sym_typedef,
-    ACTIONS(433), 1,
+    ACTIONS(449), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    STATE(88), 2,
+    STATE(89), 2,
       sym__definition,
       aux_sym_source_file_repeat1,
-    STATE(91), 5,
+    STATE(92), 5,
       sym_namespace_statement,
       sym_dictionary_statement,
       sym_enum_statement,
       sym_includes_statement,
       sym_typedef_statement,
-  [6309] = 5,
-    ACTIONS(440), 1,
+  [6341] = 5,
+    ACTIONS(426), 1,
       sym__integer,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(436), 2,
+    ACTIONS(422), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(438), 4,
+    ACTIONS(424), 4,
       anon_sym_DASHInfinity,
       anon_sym_Infinity,
       anon_sym_NaN,
       sym__decimal,
-    STATE(241), 4,
+    STATE(251), 4,
       sym__const_value,
       sym_integer_literal,
       sym_boolean_literal,
       sym_float_literal,
-  [6333] = 3,
-    ACTIONS(442), 1,
-      ts_builtin_sym_end,
+  [6365] = 4,
+    ACTIONS(452), 1,
+      sym_identifier,
+    STATE(210), 1,
+      sym_extended_attribute,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(444), 6,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_typedef,
-      sym_identifier,
-  [6349] = 3,
-    ACTIONS(446), 1,
-      ts_builtin_sym_end,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(448), 6,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_typedef,
-      sym_identifier,
-  [6365] = 3,
-    ACTIONS(450), 1,
-      ts_builtin_sym_end,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(452), 6,
-      anon_sym_dictionary,
-      anon_sym_enum,
-      anon_sym_namespace,
-      anon_sym_partial,
-      anon_sym_typedef,
-      sym_identifier,
-  [6381] = 3,
+    STATE(205), 5,
+      sym_extended_attribute_no_args,
+      sym_extended_attribute_named_arg_list,
+      sym_extended_attribute_ident,
+      sym_extended_attribute_ident_list,
+      sym_extended_attribute_wildcard,
+  [6383] = 3,
     ACTIONS(454), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13594,7 +13552,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6397] = 3,
+  [6399] = 3,
     ACTIONS(458), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13607,7 +13565,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6413] = 3,
+  [6415] = 3,
     ACTIONS(462), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13620,7 +13578,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6429] = 3,
+  [6431] = 3,
     ACTIONS(466), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13633,7 +13591,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6445] = 3,
+  [6447] = 3,
     ACTIONS(470), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13646,103 +13604,100 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6461] = 4,
+  [6463] = 3,
     ACTIONS(474), 1,
-      sym_identifier,
-    STATE(188), 1,
-      sym_extended_attribute,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    STATE(226), 5,
-      sym_extended_attribute_no_args,
-      sym_extended_attribute_named_arg_list,
-      sym_extended_attribute_ident,
-      sym_extended_attribute_ident_list,
-      sym_extended_attribute_wildcard,
-  [6479] = 3,
-    ACTIONS(476), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(478), 6,
+    ACTIONS(476), 6,
       anon_sym_dictionary,
       anon_sym_enum,
       anon_sym_namespace,
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6495] = 4,
-    ACTIONS(474), 1,
+  [6479] = 4,
+    ACTIONS(452), 1,
       sym_identifier,
-    STATE(194), 1,
+    STATE(187), 1,
       sym_extended_attribute,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    STATE(226), 5,
+    STATE(205), 5,
       sym_extended_attribute_no_args,
       sym_extended_attribute_named_arg_list,
       sym_extended_attribute_ident,
       sym_extended_attribute_ident_list,
       sym_extended_attribute_wildcard,
-  [6513] = 4,
-    ACTIONS(474), 1,
-      sym_identifier,
-    STATE(225), 1,
-      sym_extended_attribute,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    STATE(226), 5,
-      sym_extended_attribute_no_args,
-      sym_extended_attribute_named_arg_list,
-      sym_extended_attribute_ident,
-      sym_extended_attribute_ident_list,
-      sym_extended_attribute_wildcard,
-  [6531] = 3,
-    ACTIONS(480), 1,
+  [6497] = 3,
+    ACTIONS(478), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(482), 6,
+    ACTIONS(480), 6,
       anon_sym_dictionary,
       anon_sym_enum,
       anon_sym_namespace,
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6547] = 3,
-    ACTIONS(484), 1,
+  [6513] = 3,
+    ACTIONS(482), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(486), 6,
+    ACTIONS(484), 6,
       anon_sym_dictionary,
       anon_sym_enum,
       anon_sym_namespace,
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6563] = 5,
-    ACTIONS(488), 1,
-      anon_sym_LBRACE,
-    ACTIONS(492), 1,
-      anon_sym_LBRACK,
-    STATE(163), 1,
-      sym_default_value,
+  [6529] = 3,
+    ACTIONS(486), 1,
+      ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(490), 4,
-      anon_sym_ConstValue,
-      anon_sym_null,
-      anon_sym_undefined,
-      sym_string,
-  [6583] = 3,
+    ACTIONS(488), 6,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_typedef,
+      sym_identifier,
+  [6545] = 4,
+    ACTIONS(452), 1,
+      sym_identifier,
+    STATE(193), 1,
+      sym_extended_attribute,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    STATE(205), 5,
+      sym_extended_attribute_no_args,
+      sym_extended_attribute_named_arg_list,
+      sym_extended_attribute_ident,
+      sym_extended_attribute_ident_list,
+      sym_extended_attribute_wildcard,
+  [6563] = 3,
+    ACTIONS(490), 1,
+      ts_builtin_sym_end,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(492), 6,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_typedef,
+      sym_identifier,
+  [6579] = 3,
     ACTIONS(494), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13755,7 +13710,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6599] = 3,
+  [6595] = 3,
     ACTIONS(498), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
@@ -13768,46 +13723,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_partial,
       anon_sym_typedef,
       sym_identifier,
-  [6615] = 7,
+  [6611] = 3,
     ACTIONS(502), 1,
-      anon_sym_LPAREN,
-    ACTIONS(504), 1,
-      anon_sym_includes,
+      ts_builtin_sym_end,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(504), 6,
+      anon_sym_dictionary,
+      anon_sym_enum,
+      anon_sym_namespace,
+      anon_sym_partial,
+      anon_sym_typedef,
+      sym_identifier,
+  [6627] = 6,
     ACTIONS(506), 1,
+      anon_sym_LPAREN,
+    ACTIONS(508), 1,
+      anon_sym_includes,
+    ACTIONS(510), 1,
       sym_identifier,
     STATE(51), 1,
       sym_operation_rest,
-    STATE(260), 1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    STATE(245), 2,
+      sym__operation_name,
       sym_operation_name_keyword,
-    STATE(263), 1,
-      sym_operation_name,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [6638] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(358), 5,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [6650] = 4,
-    ACTIONS(508), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(324), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(326), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6666] = 4,
-    ACTIONS(510), 1,
+  [6648] = 4,
+    ACTIONS(512), 1,
       anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -13818,175 +13763,60 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(332), 2,
       anon_sym_LPAREN,
       anon_sym_QMARK,
-  [6682] = 2,
+  [6664] = 4,
+    ACTIONS(514), 1,
+      anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(380), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
+    ACTIONS(324), 2,
+      anon_sym_includes,
       sym_identifier,
-  [6693] = 3,
-    ACTIONS(512), 1,
+    ACTIONS(326), 2,
+      anon_sym_LPAREN,
       anon_sym_QMARK,
+  [6680] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(346), 3,
-      anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [6706] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(342), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [6717] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(326), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [6728] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(384), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [6739] = 4,
-    ACTIONS(516), 1,
-      anon_sym_EQ,
-    STATE(224), 1,
-      sym_default,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(514), 2,
+    ACTIONS(386), 5,
       anon_sym_RPAREN,
       anon_sym_COMMA,
-  [6754] = 3,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [6692] = 3,
+    STATE(282), 1,
+      sym_string_type,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(516), 3,
+      anon_sym_ByteString,
+      anon_sym_DOMString,
+      anon_sym_USVString,
+  [6705] = 4,
+    ACTIONS(348), 1,
+      anon_sym_LPAREN,
     ACTIONS(518), 1,
       anon_sym_QMARK,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(352), 3,
-      anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [6767] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(332), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [6778] = 3,
-    ACTIONS(520), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(332), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [6791] = 4,
-    ACTIONS(352), 1,
-      anon_sym_LPAREN,
-    ACTIONS(522), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(350), 2,
+    ACTIONS(346), 2,
       anon_sym_includes,
       sym_identifier,
-  [6806] = 3,
-    ACTIONS(524), 1,
-      anon_sym_long,
+  [6720] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(326), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [6819] = 4,
-    ACTIONS(346), 1,
-      anon_sym_LPAREN,
-    ACTIONS(526), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(344), 2,
+    ACTIONS(352), 2,
       anon_sym_includes,
       sym_identifier,
-  [6834] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(340), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(342), 2,
+    ACTIONS(354), 2,
       anon_sym_LPAREN,
       anon_sym_QMARK,
-  [6847] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(330), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(332), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6860] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(336), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(338), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6873] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(356), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(358), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6886] = 3,
-    STATE(315), 1,
-      sym_string_type,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(528), 3,
-      anon_sym_ByteString,
-      anon_sym_DOMString,
-      anon_sym_USVString,
-  [6899] = 3,
+  [6733] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -13996,89 +13826,28 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(326), 2,
       anon_sym_LPAREN,
       anon_sym_QMARK,
-  [6912] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(374), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(376), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6925] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(378), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(380), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6938] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(370), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(372), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6951] = 4,
-    ACTIONS(366), 1,
-      anon_sym_LPAREN,
-    ACTIONS(530), 1,
+  [6746] = 3,
+    ACTIONS(520), 1,
       anon_sym_QMARK,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(364), 2,
-      anon_sym_includes,
-      sym_identifier,
-  [6966] = 4,
-    ACTIONS(388), 1,
-      anon_sym_LPAREN,
-    ACTIONS(532), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(386), 2,
-      anon_sym_includes,
-      sym_identifier,
-  [6981] = 3,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(382), 2,
-      anon_sym_includes,
-      sym_identifier,
-    ACTIONS(384), 2,
-      anon_sym_LPAREN,
-      anon_sym_QMARK,
-  [6994] = 3,
-    ACTIONS(534), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(366), 3,
+    ACTIONS(342), 3,
       anon_sym_RPAREN,
       anon_sym_GT,
       sym_identifier,
-  [7007] = 2,
+  [6759] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(338), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
+    ACTIONS(392), 2,
+      anon_sym_includes,
       sym_identifier,
-  [7018] = 3,
-    ACTIONS(536), 1,
+    ACTIONS(394), 2,
+      anon_sym_LPAREN,
+      anon_sym_QMARK,
+  [6772] = 3,
+    ACTIONS(522), 1,
       anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
@@ -14087,84 +13856,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_QMARK,
       anon_sym_GT,
-  [7031] = 2,
+  [6785] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(376), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
+    ACTIONS(384), 2,
+      anon_sym_includes,
       sym_identifier,
-  [7042] = 3,
-    ACTIONS(538), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(326), 3,
-      anon_sym_RPAREN,
+    ACTIONS(386), 2,
+      anon_sym_LPAREN,
       anon_sym_QMARK,
-      anon_sym_GT,
-  [7055] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(372), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [7066] = 3,
-    STATE(299), 1,
-      sym_string_type,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(528), 3,
-      anon_sym_ByteString,
-      anon_sym_DOMString,
-      anon_sym_USVString,
-  [7079] = 3,
-    ACTIONS(540), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(388), 3,
-      anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [7092] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(362), 4,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_GT,
-      sym_identifier,
-  [7103] = 3,
-    STATE(308), 1,
-      sym_string_type,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(528), 3,
-      anon_sym_ByteString,
-      anon_sym_DOMString,
-      anon_sym_USVString,
-  [7116] = 3,
-    STATE(312), 1,
-      sym_string_type,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(528), 3,
-      anon_sym_ByteString,
-      anon_sym_DOMString,
-      anon_sym_USVString,
-  [7129] = 3,
+  [6798] = 3,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -14174,34 +13876,19 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(362), 2,
       anon_sym_LPAREN,
       anon_sym_QMARK,
-  [7142] = 4,
-    ACTIONS(542), 1,
+  [6811] = 3,
+    ACTIONS(524), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(376), 3,
       anon_sym_RPAREN,
-    ACTIONS(544), 1,
-      anon_sym_COMMA,
-    STATE(169), 1,
-      aux_sym_argument_list_repeat1,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7156] = 3,
-    ACTIONS(352), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(350), 2,
-      anon_sym_includes,
+      anon_sym_GT,
       sym_identifier,
-  [7168] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(546), 3,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-      anon_sym_EQ,
-  [7178] = 2,
+  [6824] = 3,
+    ACTIONS(526), 1,
+      anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -14209,193 +13896,495 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_QMARK,
       anon_sym_or,
-  [7188] = 2,
+  [6837] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(362), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [6848] = 3,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(330), 2,
+      anon_sym_includes,
+      sym_identifier,
+    ACTIONS(332), 2,
+      anon_sym_LPAREN,
+      anon_sym_QMARK,
+  [6861] = 4,
+    ACTIONS(342), 1,
+      anon_sym_LPAREN,
+    ACTIONS(528), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(340), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [6876] = 3,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(356), 2,
+      anon_sym_includes,
+      sym_identifier,
+    ACTIONS(358), 2,
+      anon_sym_LPAREN,
+      anon_sym_QMARK,
+  [6889] = 3,
+    ACTIONS(530), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(348), 3,
+      anon_sym_RPAREN,
+      anon_sym_GT,
+      sym_identifier,
+  [6902] = 3,
+    ACTIONS(532), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(370), 3,
+      anon_sym_RPAREN,
+      anon_sym_GT,
+      sym_identifier,
+  [6915] = 3,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(364), 2,
+      anon_sym_includes,
+      sym_identifier,
+    ACTIONS(366), 2,
+      anon_sym_LPAREN,
+      anon_sym_QMARK,
+  [6928] = 4,
+    ACTIONS(370), 1,
+      anon_sym_LPAREN,
+    ACTIONS(534), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(368), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [6943] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(366), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [6954] = 3,
+    ACTIONS(536), 1,
+      anon_sym_long,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(332), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [6967] = 4,
+    ACTIONS(376), 1,
+      anon_sym_LPAREN,
+    ACTIONS(538), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(374), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [6982] = 3,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(380), 2,
+      anon_sym_includes,
+      sym_identifier,
+    ACTIONS(382), 2,
+      anon_sym_LPAREN,
+      anon_sym_QMARK,
+  [6995] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(332), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7006] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(358), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7017] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(354), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7028] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(382), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7039] = 4,
+    ACTIONS(542), 1,
+      anon_sym_EQ,
+    STATE(204), 1,
+      sym_default,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(540), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [7054] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(326), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7065] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(390), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7076] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(394), 4,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+      sym_identifier,
+  [7087] = 3,
+    ACTIONS(544), 1,
+      anon_sym_long,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(326), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_GT,
+  [7100] = 3,
+    STATE(306), 1,
+      sym_string_type,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(516), 3,
+      anon_sym_ByteString,
+      anon_sym_DOMString,
+      anon_sym_USVString,
+  [7113] = 3,
+    STATE(310), 1,
+      sym_string_type,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(516), 3,
+      anon_sym_ByteString,
+      anon_sym_DOMString,
+      anon_sym_USVString,
+  [7126] = 3,
+    STATE(313), 1,
+      sym_string_type,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(516), 3,
+      anon_sym_ByteString,
+      anon_sym_DOMString,
+      anon_sym_USVString,
+  [7139] = 3,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(388), 2,
+      anon_sym_includes,
+      sym_identifier,
+    ACTIONS(390), 2,
+      anon_sym_LPAREN,
+      anon_sym_QMARK,
+  [7152] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(546), 3,
+      anon_sym_RPAREN,
+      anon_sym_SEMI,
+      anon_sym_COMMA,
+  [7162] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(376), 3,
       anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7198] = 3,
-    ACTIONS(394), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(392), 2,
-      anon_sym_includes,
+      anon_sym_GT,
       sym_identifier,
-  [7210] = 4,
-    ACTIONS(330), 1,
-      sym_identifier,
-    ACTIONS(332), 1,
-      anon_sym_QMARK,
-    ACTIONS(548), 1,
-      anon_sym_long,
+  [7172] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7224] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(372), 3,
+    ACTIONS(548), 3,
       anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7234] = 3,
-    ACTIONS(550), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(366), 2,
-      anon_sym_RPAREN,
-      anon_sym_or,
-  [7246] = 3,
-    ACTIONS(398), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(396), 2,
-      anon_sym_includes,
-      sym_identifier,
-  [7258] = 3,
-    ACTIONS(552), 1,
-      anon_sym_QMARK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(388), 2,
-      anon_sym_RPAREN,
-      anon_sym_or,
-  [7270] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(384), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7280] = 4,
-    ACTIONS(554), 1,
+      anon_sym_SEMI,
       anon_sym_COMMA,
+  [7182] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(550), 3,
+      anon_sym_RPAREN,
+      anon_sym_SEMI,
+      anon_sym_COMMA,
+  [7192] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(552), 3,
+      anon_sym_RPAREN,
+      anon_sym_SEMI,
+      anon_sym_COMMA,
+  [7202] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(554), 3,
+      anon_sym_RPAREN,
+      anon_sym_SEMI,
+      anon_sym_COMMA,
+  [7212] = 4,
     ACTIONS(556), 1,
+      anon_sym_LBRACE,
+    ACTIONS(558), 1,
+      anon_sym_COLON,
+    STATE(287), 1,
+      sym_inheritance,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7226] = 4,
+    ACTIONS(560), 1,
+      anon_sym_COMMA,
+    ACTIONS(562), 1,
       anon_sym_RBRACE,
-    STATE(179), 1,
+    STATE(183), 1,
       aux_sym__enum_value_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7294] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(558), 3,
+  [7240] = 4,
+    ACTIONS(564), 1,
       anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [7304] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(406), 3,
-      anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [7314] = 4,
-    ACTIONS(560), 1,
-      anon_sym_RPAREN,
-    ACTIONS(562), 1,
-      anon_sym_COMMA,
-    STATE(173), 1,
-      aux_sym_identifier_list_repeat1,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7328] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(564), 3,
-      anon_sym_RPAREN,
-      anon_sym_SEMI,
-      anon_sym_COMMA,
-  [7338] = 3,
     ACTIONS(566), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(568), 2,
       anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [7350] = 3,
-    ACTIONS(402), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(400), 2,
-      anon_sym_includes,
-      sym_identifier,
-  [7362] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(570), 3,
-      anon_sym_RPAREN,
-      anon_sym_SEMI,
-      anon_sym_COMMA,
-  [7372] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(352), 3,
-      anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [7382] = 4,
-    ACTIONS(324), 1,
-      sym_identifier,
-    ACTIONS(326), 1,
-      anon_sym_QMARK,
-    ACTIONS(572), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7396] = 4,
-    ACTIONS(574), 1,
-      anon_sym_RPAREN,
-    ACTIONS(576), 1,
-      anon_sym_COMMA,
-    STATE(169), 1,
+    STATE(162), 1,
       aux_sym_argument_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7410] = 4,
-    ACTIONS(579), 1,
+  [7254] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(568), 3,
+      anon_sym_RPAREN,
       anon_sym_COMMA,
-    ACTIONS(582), 1,
+      anon_sym_EQ,
+  [7264] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(410), 3,
+      anon_sym_RPAREN,
+      anon_sym_GT,
+      sym_identifier,
+  [7274] = 4,
+    ACTIONS(570), 1,
+      anon_sym_RPAREN,
+    ACTIONS(572), 1,
+      anon_sym_COMMA,
+    STATE(163), 1,
+      aux_sym_identifier_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7288] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(574), 3,
+      anon_sym_RPAREN,
+      anon_sym_GT,
+      sym_identifier,
+  [7298] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(576), 3,
+      anon_sym_RPAREN,
+      anon_sym_SEMI,
+      anon_sym_COMMA,
+  [7308] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(342), 3,
+      anon_sym_RPAREN,
+      anon_sym_GT,
+      sym_identifier,
+  [7318] = 4,
+    ACTIONS(578), 1,
+      anon_sym_RPAREN,
+    ACTIONS(580), 1,
+      anon_sym_COMMA,
+    STATE(162), 1,
+      aux_sym_argument_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7332] = 4,
+    ACTIONS(583), 1,
+      anon_sym_RPAREN,
+    ACTIONS(585), 1,
+      anon_sym_COMMA,
+    STATE(163), 1,
+      aux_sym_identifier_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7346] = 3,
+    ACTIONS(588), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(348), 2,
+      anon_sym_RPAREN,
+      anon_sym_or,
+  [7358] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(354), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7368] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(326), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7378] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(394), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7388] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(386), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7398] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(362), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7408] = 4,
+    ACTIONS(590), 1,
+      anon_sym_LPAREN,
+    ACTIONS(592), 1,
+      anon_sym_STAR,
+    ACTIONS(594), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7422] = 4,
+    ACTIONS(324), 1,
+      sym_identifier,
+    ACTIONS(326), 1,
+      anon_sym_QMARK,
+    ACTIONS(596), 1,
+      anon_sym_long,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7436] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(332), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7446] = 4,
+    ACTIONS(598), 1,
+      anon_sym_COMMA,
+    ACTIONS(600), 1,
       anon_sym_RBRACK,
-    STATE(170), 1,
+    STATE(190), 1,
       aux_sym_extended_attribute_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7424] = 2,
+  [7460] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(402), 3,
+    ACTIONS(358), 3,
       anon_sym_RPAREN,
-      anon_sym_GT,
-      sym_identifier,
-  [7434] = 3,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7470] = 3,
     ACTIONS(406), 1,
       anon_sym_LPAREN,
     ACTIONS(3), 2,
@@ -14404,17 +14393,125 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(404), 2,
       anon_sym_includes,
       sym_identifier,
-  [7446] = 4,
-    ACTIONS(584), 1,
-      anon_sym_RPAREN,
-    ACTIONS(586), 1,
-      anon_sym_COMMA,
-    STATE(173), 1,
-      aux_sym_identifier_list_repeat1,
+  [7482] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7460] = 2,
+    ACTIONS(366), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7492] = 3,
+    ACTIONS(602), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(370), 2,
+      anon_sym_RPAREN,
+      anon_sym_or,
+  [7504] = 3,
+    ACTIONS(402), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(400), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [7516] = 3,
+    ACTIONS(604), 1,
+      anon_sym_QMARK,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(376), 2,
+      anon_sym_RPAREN,
+      anon_sym_or,
+  [7528] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(382), 3,
+      anon_sym_RPAREN,
+      anon_sym_QMARK,
+      anon_sym_or,
+  [7538] = 4,
+    ACTIONS(542), 1,
+      anon_sym_EQ,
+    ACTIONS(606), 1,
+      anon_sym_SEMI,
+    STATE(289), 1,
+      sym_default,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7552] = 3,
+    ACTIONS(398), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(396), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [7564] = 4,
+    ACTIONS(608), 1,
+      anon_sym_COMMA,
+    ACTIONS(610), 1,
+      anon_sym_RBRACE,
+    STATE(196), 1,
+      aux_sym__enum_value_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7578] = 3,
+    ACTIONS(376), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(374), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [7590] = 3,
+    ACTIONS(410), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(408), 2,
+      anon_sym_includes,
+      sym_identifier,
+  [7602] = 3,
+    ACTIONS(614), 1,
+      anon_sym_EQ,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(612), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [7614] = 4,
+    ACTIONS(598), 1,
+      anon_sym_COMMA,
+    ACTIONS(616), 1,
+      anon_sym_RBRACK,
+    STATE(173), 1,
+      aux_sym_extended_attribute_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7628] = 3,
+    ACTIONS(618), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(620), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [7640] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -14422,1024 +14519,886 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RPAREN,
       anon_sym_GT,
       sym_identifier,
-  [7470] = 4,
-    ACTIONS(516), 1,
-      anon_sym_EQ,
-    ACTIONS(589), 1,
-      anon_sym_SEMI,
-    STATE(242), 1,
-      sym_default,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7484] = 4,
-    ACTIONS(591), 1,
-      anon_sym_LPAREN,
-    ACTIONS(593), 1,
-      anon_sym_STAR,
-    ACTIONS(595), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7498] = 4,
-    ACTIONS(597), 1,
-      anon_sym_LBRACE,
-    ACTIONS(599), 1,
-      anon_sym_COLON,
-    STATE(294), 1,
-      sym_inheritance,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7512] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(601), 3,
-      anon_sym_RPAREN,
+  [7650] = 4,
+    ACTIONS(622), 1,
       anon_sym_COMMA,
-      anon_sym_EQ,
-  [7522] = 4,
-    ACTIONS(603), 1,
-      anon_sym_COMMA,
-    ACTIONS(606), 1,
-      anon_sym_RBRACE,
-    STATE(179), 1,
-      aux_sym__enum_value_list_repeat1,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7536] = 4,
-    ACTIONS(608), 1,
-      anon_sym_COMMA,
-    ACTIONS(610), 1,
+    ACTIONS(625), 1,
       anon_sym_RBRACK,
-    STATE(170), 1,
+    STATE(190), 1,
       aux_sym_extended_attribute_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7550] = 3,
-    ACTIONS(612), 1,
-      anon_sym_QMARK,
+  [7664] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(346), 2,
-      anon_sym_RPAREN,
-      anon_sym_or,
-  [7562] = 4,
-    ACTIONS(544), 1,
-      anon_sym_COMMA,
-    ACTIONS(614), 1,
-      anon_sym_RPAREN,
-    STATE(147), 1,
-      aux_sym_argument_list_repeat1,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7576] = 4,
-    ACTIONS(616), 1,
-      anon_sym_COMMA,
-    ACTIONS(618), 1,
-      anon_sym_RBRACE,
-    STATE(159), 1,
-      aux_sym__enum_value_list_repeat1,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7590] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(342), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7600] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(394), 3,
+    ACTIONS(402), 3,
       anon_sym_RPAREN,
       anon_sym_GT,
       sym_identifier,
-  [7610] = 2,
+  [7674] = 4,
+    ACTIONS(330), 1,
+      sym_identifier,
+    ACTIONS(332), 1,
+      anon_sym_QMARK,
+    ACTIONS(627), 1,
+      anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(332), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7620] = 4,
-    ACTIONS(562), 1,
+  [7688] = 4,
+    ACTIONS(598), 1,
       anon_sym_COMMA,
-    ACTIONS(620), 1,
+    ACTIONS(629), 1,
+      anon_sym_RBRACK,
+    STATE(194), 1,
+      aux_sym_extended_attribute_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7702] = 4,
+    ACTIONS(598), 1,
+      anon_sym_COMMA,
+    ACTIONS(631), 1,
+      anon_sym_RBRACK,
+    STATE(190), 1,
+      aux_sym_extended_attribute_list_repeat1,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7716] = 4,
+    ACTIONS(572), 1,
+      anon_sym_COMMA,
+    ACTIONS(633), 1,
       anon_sym_RPAREN,
-    STATE(162), 1,
+    STATE(158), 1,
       aux_sym_identifier_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7634] = 4,
-    ACTIONS(608), 1,
+  [7730] = 4,
+    ACTIONS(635), 1,
       anon_sym_COMMA,
-    ACTIONS(622), 1,
-      anon_sym_RBRACK,
-    STATE(189), 1,
-      aux_sym_extended_attribute_list_repeat1,
+    ACTIONS(638), 1,
+      anon_sym_RBRACE,
+    STATE(196), 1,
+      aux_sym__enum_value_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7648] = 4,
-    ACTIONS(608), 1,
-      anon_sym_COMMA,
-    ACTIONS(624), 1,
-      anon_sym_RBRACK,
-    STATE(170), 1,
-      aux_sym_extended_attribute_list_repeat1,
+  [7744] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7662] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(388), 3,
+    ACTIONS(406), 3,
       anon_sym_RPAREN,
       anon_sym_GT,
       sym_identifier,
-  [7672] = 2,
+  [7754] = 4,
+    ACTIONS(566), 1,
+      anon_sym_COMMA,
+    ACTIONS(640), 1,
+      anon_sym_RPAREN,
+    STATE(155), 1,
+      aux_sym_argument_list_repeat1,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(626), 3,
+  [7768] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(642), 3,
       anon_sym_RPAREN,
       anon_sym_GT,
       sym_identifier,
-  [7682] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(628), 3,
-      anon_sym_RPAREN,
-      anon_sym_SEMI,
-      anon_sym_COMMA,
-  [7692] = 3,
-    ACTIONS(632), 1,
-      anon_sym_EQ,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(630), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [7704] = 4,
-    ACTIONS(608), 1,
-      anon_sym_COMMA,
-    ACTIONS(634), 1,
-      anon_sym_RBRACK,
-    STATE(180), 1,
-      aux_sym_extended_attribute_list_repeat1,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7718] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(338), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7728] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(358), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7738] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(362), 3,
-      anon_sym_RPAREN,
-      anon_sym_QMARK,
-      anon_sym_or,
-  [7748] = 3,
-    ACTIONS(388), 1,
+  [7778] = 3,
+    ACTIONS(342), 1,
       anon_sym_LPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(386), 2,
+    ACTIONS(340), 2,
       anon_sym_includes,
       sym_identifier,
-  [7760] = 3,
-    ACTIONS(636), 1,
+  [7790] = 3,
+    ACTIONS(644), 1,
+      anon_sym_RBRACE,
+    ACTIONS(646), 1,
       sym_string,
-    STATE(292), 1,
-      sym__enum_value_list,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7771] = 2,
+  [7801] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(380), 2,
-      anon_sym_RPAREN,
-      anon_sym_or,
-  [7780] = 3,
-    ACTIONS(536), 1,
-      anon_sym_short,
-    ACTIONS(638), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7791] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(574), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [7800] = 3,
-    ACTIONS(640), 1,
-      sym_identifier,
-    STATE(262), 1,
-      sym_identifier_list,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7811] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(642), 2,
+    ACTIONS(648), 2,
       anon_sym_float,
       anon_sym_double,
-  [7820] = 2,
+  [7810] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(644), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [7829] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(646), 2,
+    ACTIONS(650), 2,
       anon_sym_COMMA,
       anon_sym_RBRACK,
-  [7838] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(388), 2,
-      anon_sym_RPAREN,
-      anon_sym_or,
-  [7847] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(584), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [7856] = 3,
-    ACTIONS(556), 1,
-      anon_sym_RBRACE,
-    ACTIONS(648), 1,
-      sym_string,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7867] = 3,
-    ACTIONS(520), 1,
-      anon_sym_short,
-    ACTIONS(650), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7878] = 2,
+  [7819] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(652), 2,
-      anon_sym_float,
-      anon_sym_double,
-  [7887] = 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [7828] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(654), 2,
       anon_sym_COMMA,
       anon_sym_RBRACK,
-  [7896] = 2,
+  [7837] = 3,
+    ACTIONS(656), 1,
+      anon_sym_RPAREN,
+    ACTIONS(658), 1,
+      anon_sym_or,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(406), 2,
+  [7848] = 3,
+    ACTIONS(660), 1,
+      sym_identifier,
+    STATE(249), 1,
+      sym_identifier_list,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7859] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(662), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [7868] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(578), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [7877] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(625), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+  [7886] = 3,
+    ACTIONS(664), 1,
+      anon_sym_dictionary,
+    ACTIONS(666), 1,
+      anon_sym_namespace,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7897] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(376), 2,
       anon_sym_RPAREN,
       anon_sym_or,
-  [7905] = 3,
-    ACTIONS(656), 1,
-      anon_sym_short,
-    ACTIONS(658), 1,
-      anon_sym_long,
+  [7906] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7916] = 2,
+    ACTIONS(410), 2,
+      anon_sym_RPAREN,
+      anon_sym_or,
+  [7915] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(660), 2,
-      anon_sym_float,
-      anon_sym_double,
-  [7925] = 3,
-    ACTIONS(536), 1,
-      anon_sym_short,
-    ACTIONS(662), 1,
-      anon_sym_long,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7936] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(664), 2,
-      anon_sym_float,
-      anon_sym_double,
-  [7945] = 3,
-    ACTIONS(666), 1,
+    ACTIONS(398), 2,
+      anon_sym_RPAREN,
+      anon_sym_or,
+  [7924] = 3,
+    ACTIONS(526), 1,
       anon_sym_short,
     ACTIONS(668), 1,
       anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7956] = 2,
+  [7935] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(670), 2,
+      anon_sym_float,
+      anon_sym_double,
+  [7944] = 3,
+    ACTIONS(672), 1,
+      sym_string,
+    STATE(254), 1,
+      sym__enum_value_list,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7955] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(674), 2,
       anon_sym_COMMA,
       anon_sym_RBRACK,
-  [7965] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(672), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [7974] = 3,
-    ACTIONS(674), 1,
-      anon_sym_dictionary,
+  [7964] = 3,
     ACTIONS(676), 1,
-      anon_sym_namespace,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [7985] = 3,
+      anon_sym_short,
     ACTIONS(678), 1,
-      anon_sym_RPAREN,
-    ACTIONS(680), 1,
-      anon_sym_or,
+      anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [7996] = 2,
+  [7975] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-    ACTIONS(682), 2,
-      anon_sym_RPAREN,
-      anon_sym_or,
-  [8005] = 2,
+    ACTIONS(680), 2,
+      anon_sym_float,
+      anon_sym_double,
+  [7984] = 3,
+    ACTIONS(544), 1,
+      anon_sym_short,
+    ACTIONS(682), 1,
+      anon_sym_long,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [7995] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
     ACTIONS(684), 2,
-      anon_sym_RPAREN,
-      anon_sym_COMMA,
-  [8014] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(582), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [8023] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(686), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-  [8032] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(606), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-  [8041] = 3,
-    ACTIONS(648), 1,
-      sym_string,
+      anon_sym_float,
+      anon_sym_double,
+  [8004] = 3,
+    ACTIONS(686), 1,
+      anon_sym_short,
     ACTIONS(688), 1,
+      anon_sym_long,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8015] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(638), 2,
+      anon_sym_COMMA,
       anon_sym_RBRACE,
+  [8024] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8052] = 2,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-    ACTIONS(402), 2,
+    ACTIONS(690), 2,
       anon_sym_RPAREN,
       anon_sym_or,
-  [8061] = 2,
-    ACTIONS(690), 1,
-      anon_sym_iterable,
+  [8033] = 2,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8069] = 2,
-    ACTIONS(692), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8077] = 2,
-    ACTIONS(694), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8085] = 2,
-    ACTIONS(696), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8093] = 2,
-    ACTIONS(698), 1,
-      ts_builtin_sym_end,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8101] = 2,
-    ACTIONS(700), 1,
+    ACTIONS(692), 2,
       anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [8042] = 3,
+    ACTIONS(544), 1,
+      anon_sym_short,
+    ACTIONS(694), 1,
+      anon_sym_long,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8109] = 2,
-    ACTIONS(702), 1,
+  [8053] = 3,
+    ACTIONS(610), 1,
+      anon_sym_RBRACE,
+    ACTIONS(646), 1,
+      sym_string,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8064] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(583), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [8073] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(696), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [8082] = 2,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+    ACTIONS(390), 2,
+      anon_sym_RPAREN,
+      anon_sym_or,
+  [8091] = 2,
+    ACTIONS(698), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8117] = 2,
-    ACTIONS(704), 1,
+  [8099] = 2,
+    ACTIONS(700), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8125] = 2,
+  [8107] = 2,
+    ACTIONS(702), 1,
+      anon_sym_LBRACE,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8115] = 2,
+    ACTIONS(704), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8123] = 2,
     ACTIONS(706), 1,
-      anon_sym_SEMI,
+      sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8133] = 2,
+  [8131] = 2,
     ACTIONS(708), 1,
-      anon_sym_SEMI,
+      anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8141] = 2,
+  [8139] = 2,
     ACTIONS(710), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8149] = 2,
+  [8147] = 2,
+    ACTIONS(658), 1,
+      anon_sym_or,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8155] = 2,
     ACTIONS(712), 1,
-      anon_sym_SEMI,
+      anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8157] = 2,
+  [8163] = 2,
     ACTIONS(714), 1,
-      anon_sym_SEMI,
+      anon_sym_LPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8165] = 2,
+  [8171] = 2,
     ACTIONS(716), 1,
-      anon_sym_SEMI,
+      anon_sym_RBRACK,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8173] = 2,
+  [8179] = 2,
     ACTIONS(718), 1,
-      sym_identifier,
+      anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8181] = 2,
+  [8187] = 2,
+    ACTIONS(646), 1,
+      sym_string,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8195] = 2,
     ACTIONS(720), 1,
-      anon_sym_includes,
+      anon_sym_LPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8189] = 2,
+  [8203] = 2,
     ACTIONS(722), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8197] = 2,
+  [8211] = 2,
     ACTIONS(724), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8205] = 2,
-    ACTIONS(726), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8213] = 2,
+  [8219] = 2,
+    ACTIONS(726), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8227] = 2,
     ACTIONS(728), 1,
-      anon_sym_EQ,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8221] = 2,
-    ACTIONS(730), 1,
-      anon_sym_iterable,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8229] = 2,
-    ACTIONS(732), 1,
-      anon_sym_LT,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8237] = 2,
-    ACTIONS(734), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8245] = 2,
-    ACTIONS(736), 1,
+  [8235] = 2,
+    ACTIONS(656), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8243] = 2,
+    ACTIONS(730), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8253] = 2,
-    ACTIONS(738), 1,
+  [8251] = 2,
+    ACTIONS(732), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8259] = 2,
+    ACTIONS(734), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8261] = 2,
+  [8267] = 2,
+    ACTIONS(736), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8275] = 2,
+    ACTIONS(738), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8283] = 2,
     ACTIONS(740), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8269] = 2,
+  [8291] = 2,
     ACTIONS(742), 1,
-      anon_sym_LBRACE,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8277] = 2,
-    ACTIONS(744), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8285] = 2,
-    ACTIONS(746), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8293] = 2,
-    ACTIONS(748), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8301] = 2,
-    ACTIONS(750), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8309] = 2,
-    ACTIONS(752), 1,
-      anon_sym_LBRACE,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8317] = 2,
-    ACTIONS(754), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8325] = 2,
-    ACTIONS(756), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8333] = 2,
-    ACTIONS(758), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8341] = 2,
-    ACTIONS(760), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8349] = 2,
-    ACTIONS(762), 1,
+  [8299] = 2,
+    ACTIONS(744), 1,
       anon_sym_GT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8357] = 2,
+  [8307] = 2,
+    ACTIONS(746), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8315] = 2,
+    ACTIONS(748), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8323] = 2,
+    ACTIONS(750), 1,
+      anon_sym_includes,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8331] = 2,
+    ACTIONS(752), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8339] = 2,
+    ACTIONS(754), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8347] = 2,
+    ACTIONS(756), 1,
+      anon_sym_LT,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8355] = 2,
+    ACTIONS(758), 1,
+      anon_sym_GT,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8363] = 2,
+    ACTIONS(760), 1,
+      sym_identifier,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8371] = 2,
+    ACTIONS(762), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8379] = 2,
     ACTIONS(764), 1,
-      anon_sym_LBRACE,
+      anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8365] = 2,
+  [8387] = 2,
     ACTIONS(766), 1,
-      anon_sym_RBRACE,
+      sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8373] = 2,
+  [8395] = 2,
     ACTIONS(768), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8381] = 2,
+  [8403] = 2,
     ACTIONS(770), 1,
-      anon_sym_SEMI,
+      anon_sym_GT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8389] = 2,
-    ACTIONS(766), 1,
-      anon_sym_RBRACK,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8397] = 2,
+  [8411] = 2,
     ACTIONS(772), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8405] = 2,
+  [8419] = 2,
     ACTIONS(774), 1,
       anon_sym_GT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8413] = 2,
+  [8427] = 2,
     ACTIONS(776), 1,
+      anon_sym_LBRACE,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8435] = 2,
+    ACTIONS(778), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8421] = 2,
-    ACTIONS(778), 1,
+  [8443] = 2,
+    ACTIONS(780), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8451] = 2,
+    ACTIONS(782), 1,
+      anon_sym_RPAREN,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8459] = 2,
+    ACTIONS(784), 1,
       anon_sym_GT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8429] = 2,
-    ACTIONS(780), 1,
-      anon_sym_SEMI,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8437] = 2,
-    ACTIONS(782), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8445] = 2,
-    ACTIONS(784), 1,
-      sym_identifier,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8453] = 2,
+  [8467] = 2,
     ACTIONS(786), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8461] = 2,
+  [8475] = 2,
     ACTIONS(788), 1,
-      anon_sym_GT,
+      sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8469] = 2,
+  [8483] = 2,
     ACTIONS(790), 1,
-      anon_sym_RPAREN,
+      sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8477] = 2,
+  [8491] = 2,
     ACTIONS(792), 1,
-      anon_sym_GT,
+      anon_sym_COMMA,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8485] = 2,
-    ACTIONS(678), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8493] = 2,
-    ACTIONS(648), 1,
-      sym_string,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8501] = 2,
+  [8499] = 2,
     ACTIONS(794), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8509] = 2,
+  [8507] = 2,
     ACTIONS(796), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8517] = 2,
+  [8515] = 2,
     ACTIONS(798), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8525] = 2,
+  [8523] = 2,
     ACTIONS(800), 1,
       anon_sym_GT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8533] = 2,
+  [8531] = 2,
     ACTIONS(802), 1,
-      anon_sym_RPAREN,
+      anon_sym_LBRACE,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8541] = 2,
+  [8539] = 2,
     ACTIONS(804), 1,
-      anon_sym_RPAREN,
+      ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8549] = 2,
+  [8547] = 2,
     ACTIONS(806), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8557] = 2,
+  [8555] = 2,
     ACTIONS(808), 1,
-      anon_sym_RBRACE,
+      anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8565] = 2,
+  [8563] = 2,
     ACTIONS(810), 1,
-      sym_identifier,
+      anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8573] = 2,
+  [8571] = 2,
     ACTIONS(812), 1,
-      anon_sym_LBRACE,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8581] = 2,
-    ACTIONS(814), 1,
-      anon_sym_GT,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8589] = 2,
-    ACTIONS(816), 1,
       sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8597] = 2,
+  [8579] = 2,
+    ACTIONS(814), 1,
+      anon_sym_iterable,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8587] = 2,
+    ACTIONS(816), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8595] = 2,
     ACTIONS(818), 1,
-      anon_sym_LBRACE,
+      anon_sym_EQ,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8605] = 2,
+  [8603] = 2,
     ACTIONS(820), 1,
+      anon_sym_SEMI,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8611] = 2,
+    ACTIONS(822), 1,
       anon_sym_LBRACE,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8613] = 2,
-    ACTIONS(822), 1,
-      anon_sym_COMMA,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8621] = 2,
+  [8619] = 2,
     ACTIONS(824), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8629] = 2,
-    ACTIONS(680), 1,
-      anon_sym_or,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8637] = 2,
+  [8627] = 2,
     ACTIONS(826), 1,
-      anon_sym_LT,
+      anon_sym_LBRACE,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8645] = 2,
+  [8635] = 2,
     ACTIONS(828), 1,
-      anon_sym_SEMI,
+      anon_sym_LBRACE,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8653] = 2,
+  [8643] = 2,
     ACTIONS(830), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8661] = 2,
+  [8651] = 2,
     ACTIONS(832), 1,
-      anon_sym_LT,
+      sym_identifier,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8669] = 2,
+  [8659] = 2,
     ACTIONS(834), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8677] = 2,
+  [8667] = 2,
     ACTIONS(836), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8685] = 2,
+  [8675] = 2,
     ACTIONS(838), 1,
-      anon_sym_COMMA,
-    ACTIONS(3), 2,
-      sym__whitespace,
-      sym_comment,
-  [8693] = 2,
-    ACTIONS(840), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8701] = 2,
+  [8683] = 2,
+    ACTIONS(840), 1,
+      anon_sym_COMMA,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8691] = 2,
     ACTIONS(842), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8709] = 2,
+  [8699] = 2,
     ACTIONS(844), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8717] = 2,
+  [8707] = 2,
+    ACTIONS(716), 1,
+      anon_sym_RBRACE,
+    ACTIONS(3), 2,
+      sym__whitespace,
+      sym_comment,
+  [8715] = 2,
     ACTIONS(846), 1,
       anon_sym_COMMA,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8725] = 2,
+  [8723] = 2,
     ACTIONS(848), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8733] = 2,
+  [8731] = 2,
     ACTIONS(850), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8741] = 2,
+  [8739] = 2,
     ACTIONS(852), 1,
       anon_sym_COMMA,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8749] = 2,
+  [8747] = 2,
     ACTIONS(854), 1,
-      sym_identifier,
+      anon_sym_iterable,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8757] = 2,
+  [8755] = 2,
     ACTIONS(856), 1,
-      anon_sym_RPAREN,
+      anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8765] = 2,
+  [8763] = 2,
     ACTIONS(858), 1,
       anon_sym_iterable,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8773] = 2,
+  [8771] = 2,
     ACTIONS(860), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8781] = 2,
+  [8779] = 2,
     ACTIONS(862), 1,
       anon_sym_iterable,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8789] = 2,
+  [8787] = 2,
     ACTIONS(864), 1,
       anon_sym_SEMI,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8797] = 2,
+  [8795] = 2,
     ACTIONS(866), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8805] = 2,
+  [8803] = 2,
     ACTIONS(868), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8813] = 2,
+  [8811] = 2,
     ACTIONS(870), 1,
       anon_sym_LT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
-  [8821] = 2,
+  [8819] = 2,
     ACTIONS(872), 1,
-      anon_sym_RPAREN,
+      anon_sym_GT,
     ACTIONS(3), 2,
       sym__whitespace,
       sym_comment,
@@ -15504,272 +15463,270 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(57)] = 5085,
   [SMALL_STATE(58)] = 5134,
   [SMALL_STATE(59)] = 5183,
-  [SMALL_STATE(60)] = 5227,
-  [SMALL_STATE(61)] = 5267,
-  [SMALL_STATE(62)] = 5307,
+  [SMALL_STATE(60)] = 5225,
+  [SMALL_STATE(61)] = 5265,
+  [SMALL_STATE(62)] = 5305,
   [SMALL_STATE(63)] = 5344,
-  [SMALL_STATE(64)] = 5381,
-  [SMALL_STATE(65)] = 5418,
-  [SMALL_STATE(66)] = 5457,
+  [SMALL_STATE(64)] = 5383,
+  [SMALL_STATE(65)] = 5422,
+  [SMALL_STATE(66)] = 5461,
   [SMALL_STATE(67)] = 5498,
-  [SMALL_STATE(68)] = 5539,
-  [SMALL_STATE(69)] = 5576,
-  [SMALL_STATE(70)] = 5615,
-  [SMALL_STATE(71)] = 5652,
-  [SMALL_STATE(72)] = 5689,
-  [SMALL_STATE(73)] = 5728,
-  [SMALL_STATE(74)] = 5765,
-  [SMALL_STATE(75)] = 5802,
-  [SMALL_STATE(76)] = 5839,
-  [SMALL_STATE(77)] = 5876,
-  [SMALL_STATE(78)] = 5915,
-  [SMALL_STATE(79)] = 5951,
-  [SMALL_STATE(80)] = 5987,
-  [SMALL_STATE(81)] = 6023,
-  [SMALL_STATE(82)] = 6059,
-  [SMALL_STATE(83)] = 6095,
-  [SMALL_STATE(84)] = 6131,
-  [SMALL_STATE(85)] = 6164,
-  [SMALL_STATE(86)] = 6197,
-  [SMALL_STATE(87)] = 6235,
-  [SMALL_STATE(88)] = 6272,
-  [SMALL_STATE(89)] = 6309,
-  [SMALL_STATE(90)] = 6333,
-  [SMALL_STATE(91)] = 6349,
-  [SMALL_STATE(92)] = 6365,
-  [SMALL_STATE(93)] = 6381,
-  [SMALL_STATE(94)] = 6397,
-  [SMALL_STATE(95)] = 6413,
-  [SMALL_STATE(96)] = 6429,
-  [SMALL_STATE(97)] = 6445,
-  [SMALL_STATE(98)] = 6461,
-  [SMALL_STATE(99)] = 6479,
-  [SMALL_STATE(100)] = 6495,
-  [SMALL_STATE(101)] = 6513,
-  [SMALL_STATE(102)] = 6531,
-  [SMALL_STATE(103)] = 6547,
-  [SMALL_STATE(104)] = 6563,
-  [SMALL_STATE(105)] = 6583,
-  [SMALL_STATE(106)] = 6599,
-  [SMALL_STATE(107)] = 6615,
-  [SMALL_STATE(108)] = 6638,
-  [SMALL_STATE(109)] = 6650,
-  [SMALL_STATE(110)] = 6666,
-  [SMALL_STATE(111)] = 6682,
-  [SMALL_STATE(112)] = 6693,
-  [SMALL_STATE(113)] = 6706,
-  [SMALL_STATE(114)] = 6717,
-  [SMALL_STATE(115)] = 6728,
-  [SMALL_STATE(116)] = 6739,
-  [SMALL_STATE(117)] = 6754,
-  [SMALL_STATE(118)] = 6767,
-  [SMALL_STATE(119)] = 6778,
-  [SMALL_STATE(120)] = 6791,
-  [SMALL_STATE(121)] = 6806,
-  [SMALL_STATE(122)] = 6819,
-  [SMALL_STATE(123)] = 6834,
-  [SMALL_STATE(124)] = 6847,
-  [SMALL_STATE(125)] = 6860,
-  [SMALL_STATE(126)] = 6873,
-  [SMALL_STATE(127)] = 6886,
-  [SMALL_STATE(128)] = 6899,
-  [SMALL_STATE(129)] = 6912,
-  [SMALL_STATE(130)] = 6925,
-  [SMALL_STATE(131)] = 6938,
-  [SMALL_STATE(132)] = 6951,
-  [SMALL_STATE(133)] = 6966,
-  [SMALL_STATE(134)] = 6981,
-  [SMALL_STATE(135)] = 6994,
-  [SMALL_STATE(136)] = 7007,
-  [SMALL_STATE(137)] = 7018,
-  [SMALL_STATE(138)] = 7031,
-  [SMALL_STATE(139)] = 7042,
-  [SMALL_STATE(140)] = 7055,
-  [SMALL_STATE(141)] = 7066,
-  [SMALL_STATE(142)] = 7079,
-  [SMALL_STATE(143)] = 7092,
-  [SMALL_STATE(144)] = 7103,
-  [SMALL_STATE(145)] = 7116,
-  [SMALL_STATE(146)] = 7129,
-  [SMALL_STATE(147)] = 7142,
-  [SMALL_STATE(148)] = 7156,
-  [SMALL_STATE(149)] = 7168,
-  [SMALL_STATE(150)] = 7178,
-  [SMALL_STATE(151)] = 7188,
-  [SMALL_STATE(152)] = 7198,
-  [SMALL_STATE(153)] = 7210,
-  [SMALL_STATE(154)] = 7224,
-  [SMALL_STATE(155)] = 7234,
-  [SMALL_STATE(156)] = 7246,
-  [SMALL_STATE(157)] = 7258,
-  [SMALL_STATE(158)] = 7270,
-  [SMALL_STATE(159)] = 7280,
-  [SMALL_STATE(160)] = 7294,
-  [SMALL_STATE(161)] = 7304,
-  [SMALL_STATE(162)] = 7314,
-  [SMALL_STATE(163)] = 7328,
-  [SMALL_STATE(164)] = 7338,
-  [SMALL_STATE(165)] = 7350,
-  [SMALL_STATE(166)] = 7362,
-  [SMALL_STATE(167)] = 7372,
-  [SMALL_STATE(168)] = 7382,
-  [SMALL_STATE(169)] = 7396,
-  [SMALL_STATE(170)] = 7410,
-  [SMALL_STATE(171)] = 7424,
-  [SMALL_STATE(172)] = 7434,
+  [SMALL_STATE(68)] = 5535,
+  [SMALL_STATE(69)] = 5572,
+  [SMALL_STATE(70)] = 5609,
+  [SMALL_STATE(71)] = 5646,
+  [SMALL_STATE(72)] = 5683,
+  [SMALL_STATE(73)] = 5722,
+  [SMALL_STATE(74)] = 5761,
+  [SMALL_STATE(75)] = 5798,
+  [SMALL_STATE(76)] = 5835,
+  [SMALL_STATE(77)] = 5872,
+  [SMALL_STATE(78)] = 5909,
+  [SMALL_STATE(79)] = 5945,
+  [SMALL_STATE(80)] = 5981,
+  [SMALL_STATE(81)] = 6017,
+  [SMALL_STATE(82)] = 6053,
+  [SMALL_STATE(83)] = 6089,
+  [SMALL_STATE(84)] = 6125,
+  [SMALL_STATE(85)] = 6158,
+  [SMALL_STATE(86)] = 6191,
+  [SMALL_STATE(87)] = 6229,
+  [SMALL_STATE(88)] = 6267,
+  [SMALL_STATE(89)] = 6304,
+  [SMALL_STATE(90)] = 6341,
+  [SMALL_STATE(91)] = 6365,
+  [SMALL_STATE(92)] = 6383,
+  [SMALL_STATE(93)] = 6399,
+  [SMALL_STATE(94)] = 6415,
+  [SMALL_STATE(95)] = 6431,
+  [SMALL_STATE(96)] = 6447,
+  [SMALL_STATE(97)] = 6463,
+  [SMALL_STATE(98)] = 6479,
+  [SMALL_STATE(99)] = 6497,
+  [SMALL_STATE(100)] = 6513,
+  [SMALL_STATE(101)] = 6529,
+  [SMALL_STATE(102)] = 6545,
+  [SMALL_STATE(103)] = 6563,
+  [SMALL_STATE(104)] = 6579,
+  [SMALL_STATE(105)] = 6595,
+  [SMALL_STATE(106)] = 6611,
+  [SMALL_STATE(107)] = 6627,
+  [SMALL_STATE(108)] = 6648,
+  [SMALL_STATE(109)] = 6664,
+  [SMALL_STATE(110)] = 6680,
+  [SMALL_STATE(111)] = 6692,
+  [SMALL_STATE(112)] = 6705,
+  [SMALL_STATE(113)] = 6720,
+  [SMALL_STATE(114)] = 6733,
+  [SMALL_STATE(115)] = 6746,
+  [SMALL_STATE(116)] = 6759,
+  [SMALL_STATE(117)] = 6772,
+  [SMALL_STATE(118)] = 6785,
+  [SMALL_STATE(119)] = 6798,
+  [SMALL_STATE(120)] = 6811,
+  [SMALL_STATE(121)] = 6824,
+  [SMALL_STATE(122)] = 6837,
+  [SMALL_STATE(123)] = 6848,
+  [SMALL_STATE(124)] = 6861,
+  [SMALL_STATE(125)] = 6876,
+  [SMALL_STATE(126)] = 6889,
+  [SMALL_STATE(127)] = 6902,
+  [SMALL_STATE(128)] = 6915,
+  [SMALL_STATE(129)] = 6928,
+  [SMALL_STATE(130)] = 6943,
+  [SMALL_STATE(131)] = 6954,
+  [SMALL_STATE(132)] = 6967,
+  [SMALL_STATE(133)] = 6982,
+  [SMALL_STATE(134)] = 6995,
+  [SMALL_STATE(135)] = 7006,
+  [SMALL_STATE(136)] = 7017,
+  [SMALL_STATE(137)] = 7028,
+  [SMALL_STATE(138)] = 7039,
+  [SMALL_STATE(139)] = 7054,
+  [SMALL_STATE(140)] = 7065,
+  [SMALL_STATE(141)] = 7076,
+  [SMALL_STATE(142)] = 7087,
+  [SMALL_STATE(143)] = 7100,
+  [SMALL_STATE(144)] = 7113,
+  [SMALL_STATE(145)] = 7126,
+  [SMALL_STATE(146)] = 7139,
+  [SMALL_STATE(147)] = 7152,
+  [SMALL_STATE(148)] = 7162,
+  [SMALL_STATE(149)] = 7172,
+  [SMALL_STATE(150)] = 7182,
+  [SMALL_STATE(151)] = 7192,
+  [SMALL_STATE(152)] = 7202,
+  [SMALL_STATE(153)] = 7212,
+  [SMALL_STATE(154)] = 7226,
+  [SMALL_STATE(155)] = 7240,
+  [SMALL_STATE(156)] = 7254,
+  [SMALL_STATE(157)] = 7264,
+  [SMALL_STATE(158)] = 7274,
+  [SMALL_STATE(159)] = 7288,
+  [SMALL_STATE(160)] = 7298,
+  [SMALL_STATE(161)] = 7308,
+  [SMALL_STATE(162)] = 7318,
+  [SMALL_STATE(163)] = 7332,
+  [SMALL_STATE(164)] = 7346,
+  [SMALL_STATE(165)] = 7358,
+  [SMALL_STATE(166)] = 7368,
+  [SMALL_STATE(167)] = 7378,
+  [SMALL_STATE(168)] = 7388,
+  [SMALL_STATE(169)] = 7398,
+  [SMALL_STATE(170)] = 7408,
+  [SMALL_STATE(171)] = 7422,
+  [SMALL_STATE(172)] = 7436,
   [SMALL_STATE(173)] = 7446,
   [SMALL_STATE(174)] = 7460,
   [SMALL_STATE(175)] = 7470,
-  [SMALL_STATE(176)] = 7484,
-  [SMALL_STATE(177)] = 7498,
-  [SMALL_STATE(178)] = 7512,
-  [SMALL_STATE(179)] = 7522,
-  [SMALL_STATE(180)] = 7536,
-  [SMALL_STATE(181)] = 7550,
-  [SMALL_STATE(182)] = 7562,
-  [SMALL_STATE(183)] = 7576,
-  [SMALL_STATE(184)] = 7590,
-  [SMALL_STATE(185)] = 7600,
-  [SMALL_STATE(186)] = 7610,
-  [SMALL_STATE(187)] = 7620,
-  [SMALL_STATE(188)] = 7634,
-  [SMALL_STATE(189)] = 7648,
-  [SMALL_STATE(190)] = 7662,
-  [SMALL_STATE(191)] = 7672,
-  [SMALL_STATE(192)] = 7682,
-  [SMALL_STATE(193)] = 7692,
-  [SMALL_STATE(194)] = 7704,
-  [SMALL_STATE(195)] = 7718,
-  [SMALL_STATE(196)] = 7728,
-  [SMALL_STATE(197)] = 7738,
-  [SMALL_STATE(198)] = 7748,
-  [SMALL_STATE(199)] = 7760,
-  [SMALL_STATE(200)] = 7771,
-  [SMALL_STATE(201)] = 7780,
-  [SMALL_STATE(202)] = 7791,
-  [SMALL_STATE(203)] = 7800,
-  [SMALL_STATE(204)] = 7811,
-  [SMALL_STATE(205)] = 7820,
-  [SMALL_STATE(206)] = 7829,
-  [SMALL_STATE(207)] = 7838,
-  [SMALL_STATE(208)] = 7847,
-  [SMALL_STATE(209)] = 7856,
-  [SMALL_STATE(210)] = 7867,
-  [SMALL_STATE(211)] = 7878,
-  [SMALL_STATE(212)] = 7887,
-  [SMALL_STATE(213)] = 7896,
-  [SMALL_STATE(214)] = 7905,
-  [SMALL_STATE(215)] = 7916,
-  [SMALL_STATE(216)] = 7925,
-  [SMALL_STATE(217)] = 7936,
-  [SMALL_STATE(218)] = 7945,
-  [SMALL_STATE(219)] = 7956,
-  [SMALL_STATE(220)] = 7965,
-  [SMALL_STATE(221)] = 7974,
-  [SMALL_STATE(222)] = 7985,
-  [SMALL_STATE(223)] = 7996,
-  [SMALL_STATE(224)] = 8005,
-  [SMALL_STATE(225)] = 8014,
-  [SMALL_STATE(226)] = 8023,
-  [SMALL_STATE(227)] = 8032,
-  [SMALL_STATE(228)] = 8041,
-  [SMALL_STATE(229)] = 8052,
-  [SMALL_STATE(230)] = 8061,
-  [SMALL_STATE(231)] = 8069,
-  [SMALL_STATE(232)] = 8077,
-  [SMALL_STATE(233)] = 8085,
-  [SMALL_STATE(234)] = 8093,
-  [SMALL_STATE(235)] = 8101,
-  [SMALL_STATE(236)] = 8109,
-  [SMALL_STATE(237)] = 8117,
-  [SMALL_STATE(238)] = 8125,
-  [SMALL_STATE(239)] = 8133,
-  [SMALL_STATE(240)] = 8141,
-  [SMALL_STATE(241)] = 8149,
-  [SMALL_STATE(242)] = 8157,
-  [SMALL_STATE(243)] = 8165,
-  [SMALL_STATE(244)] = 8173,
-  [SMALL_STATE(245)] = 8181,
-  [SMALL_STATE(246)] = 8189,
-  [SMALL_STATE(247)] = 8197,
-  [SMALL_STATE(248)] = 8205,
-  [SMALL_STATE(249)] = 8213,
-  [SMALL_STATE(250)] = 8221,
-  [SMALL_STATE(251)] = 8229,
-  [SMALL_STATE(252)] = 8237,
-  [SMALL_STATE(253)] = 8245,
-  [SMALL_STATE(254)] = 8253,
-  [SMALL_STATE(255)] = 8261,
-  [SMALL_STATE(256)] = 8269,
-  [SMALL_STATE(257)] = 8277,
-  [SMALL_STATE(258)] = 8285,
-  [SMALL_STATE(259)] = 8293,
-  [SMALL_STATE(260)] = 8301,
-  [SMALL_STATE(261)] = 8309,
-  [SMALL_STATE(262)] = 8317,
-  [SMALL_STATE(263)] = 8325,
-  [SMALL_STATE(264)] = 8333,
-  [SMALL_STATE(265)] = 8341,
-  [SMALL_STATE(266)] = 8349,
-  [SMALL_STATE(267)] = 8357,
-  [SMALL_STATE(268)] = 8365,
-  [SMALL_STATE(269)] = 8373,
-  [SMALL_STATE(270)] = 8381,
-  [SMALL_STATE(271)] = 8389,
-  [SMALL_STATE(272)] = 8397,
-  [SMALL_STATE(273)] = 8405,
-  [SMALL_STATE(274)] = 8413,
-  [SMALL_STATE(275)] = 8421,
-  [SMALL_STATE(276)] = 8429,
-  [SMALL_STATE(277)] = 8437,
-  [SMALL_STATE(278)] = 8445,
-  [SMALL_STATE(279)] = 8453,
-  [SMALL_STATE(280)] = 8461,
-  [SMALL_STATE(281)] = 8469,
-  [SMALL_STATE(282)] = 8477,
-  [SMALL_STATE(283)] = 8485,
-  [SMALL_STATE(284)] = 8493,
-  [SMALL_STATE(285)] = 8501,
-  [SMALL_STATE(286)] = 8509,
-  [SMALL_STATE(287)] = 8517,
-  [SMALL_STATE(288)] = 8525,
-  [SMALL_STATE(289)] = 8533,
-  [SMALL_STATE(290)] = 8541,
-  [SMALL_STATE(291)] = 8549,
-  [SMALL_STATE(292)] = 8557,
-  [SMALL_STATE(293)] = 8565,
-  [SMALL_STATE(294)] = 8573,
-  [SMALL_STATE(295)] = 8581,
-  [SMALL_STATE(296)] = 8589,
-  [SMALL_STATE(297)] = 8597,
-  [SMALL_STATE(298)] = 8605,
-  [SMALL_STATE(299)] = 8613,
-  [SMALL_STATE(300)] = 8621,
-  [SMALL_STATE(301)] = 8629,
-  [SMALL_STATE(302)] = 8637,
-  [SMALL_STATE(303)] = 8645,
-  [SMALL_STATE(304)] = 8653,
-  [SMALL_STATE(305)] = 8661,
-  [SMALL_STATE(306)] = 8669,
-  [SMALL_STATE(307)] = 8677,
-  [SMALL_STATE(308)] = 8685,
-  [SMALL_STATE(309)] = 8693,
-  [SMALL_STATE(310)] = 8701,
-  [SMALL_STATE(311)] = 8709,
-  [SMALL_STATE(312)] = 8717,
-  [SMALL_STATE(313)] = 8725,
-  [SMALL_STATE(314)] = 8733,
-  [SMALL_STATE(315)] = 8741,
-  [SMALL_STATE(316)] = 8749,
-  [SMALL_STATE(317)] = 8757,
-  [SMALL_STATE(318)] = 8765,
-  [SMALL_STATE(319)] = 8773,
-  [SMALL_STATE(320)] = 8781,
-  [SMALL_STATE(321)] = 8789,
-  [SMALL_STATE(322)] = 8797,
-  [SMALL_STATE(323)] = 8805,
-  [SMALL_STATE(324)] = 8813,
-  [SMALL_STATE(325)] = 8821,
+  [SMALL_STATE(176)] = 7482,
+  [SMALL_STATE(177)] = 7492,
+  [SMALL_STATE(178)] = 7504,
+  [SMALL_STATE(179)] = 7516,
+  [SMALL_STATE(180)] = 7528,
+  [SMALL_STATE(181)] = 7538,
+  [SMALL_STATE(182)] = 7552,
+  [SMALL_STATE(183)] = 7564,
+  [SMALL_STATE(184)] = 7578,
+  [SMALL_STATE(185)] = 7590,
+  [SMALL_STATE(186)] = 7602,
+  [SMALL_STATE(187)] = 7614,
+  [SMALL_STATE(188)] = 7628,
+  [SMALL_STATE(189)] = 7640,
+  [SMALL_STATE(190)] = 7650,
+  [SMALL_STATE(191)] = 7664,
+  [SMALL_STATE(192)] = 7674,
+  [SMALL_STATE(193)] = 7688,
+  [SMALL_STATE(194)] = 7702,
+  [SMALL_STATE(195)] = 7716,
+  [SMALL_STATE(196)] = 7730,
+  [SMALL_STATE(197)] = 7744,
+  [SMALL_STATE(198)] = 7754,
+  [SMALL_STATE(199)] = 7768,
+  [SMALL_STATE(200)] = 7778,
+  [SMALL_STATE(201)] = 7790,
+  [SMALL_STATE(202)] = 7801,
+  [SMALL_STATE(203)] = 7810,
+  [SMALL_STATE(204)] = 7819,
+  [SMALL_STATE(205)] = 7828,
+  [SMALL_STATE(206)] = 7837,
+  [SMALL_STATE(207)] = 7848,
+  [SMALL_STATE(208)] = 7859,
+  [SMALL_STATE(209)] = 7868,
+  [SMALL_STATE(210)] = 7877,
+  [SMALL_STATE(211)] = 7886,
+  [SMALL_STATE(212)] = 7897,
+  [SMALL_STATE(213)] = 7906,
+  [SMALL_STATE(214)] = 7915,
+  [SMALL_STATE(215)] = 7924,
+  [SMALL_STATE(216)] = 7935,
+  [SMALL_STATE(217)] = 7944,
+  [SMALL_STATE(218)] = 7955,
+  [SMALL_STATE(219)] = 7964,
+  [SMALL_STATE(220)] = 7975,
+  [SMALL_STATE(221)] = 7984,
+  [SMALL_STATE(222)] = 7995,
+  [SMALL_STATE(223)] = 8004,
+  [SMALL_STATE(224)] = 8015,
+  [SMALL_STATE(225)] = 8024,
+  [SMALL_STATE(226)] = 8033,
+  [SMALL_STATE(227)] = 8042,
+  [SMALL_STATE(228)] = 8053,
+  [SMALL_STATE(229)] = 8064,
+  [SMALL_STATE(230)] = 8073,
+  [SMALL_STATE(231)] = 8082,
+  [SMALL_STATE(232)] = 8091,
+  [SMALL_STATE(233)] = 8099,
+  [SMALL_STATE(234)] = 8107,
+  [SMALL_STATE(235)] = 8115,
+  [SMALL_STATE(236)] = 8123,
+  [SMALL_STATE(237)] = 8131,
+  [SMALL_STATE(238)] = 8139,
+  [SMALL_STATE(239)] = 8147,
+  [SMALL_STATE(240)] = 8155,
+  [SMALL_STATE(241)] = 8163,
+  [SMALL_STATE(242)] = 8171,
+  [SMALL_STATE(243)] = 8179,
+  [SMALL_STATE(244)] = 8187,
+  [SMALL_STATE(245)] = 8195,
+  [SMALL_STATE(246)] = 8203,
+  [SMALL_STATE(247)] = 8211,
+  [SMALL_STATE(248)] = 8219,
+  [SMALL_STATE(249)] = 8227,
+  [SMALL_STATE(250)] = 8235,
+  [SMALL_STATE(251)] = 8243,
+  [SMALL_STATE(252)] = 8251,
+  [SMALL_STATE(253)] = 8259,
+  [SMALL_STATE(254)] = 8267,
+  [SMALL_STATE(255)] = 8275,
+  [SMALL_STATE(256)] = 8283,
+  [SMALL_STATE(257)] = 8291,
+  [SMALL_STATE(258)] = 8299,
+  [SMALL_STATE(259)] = 8307,
+  [SMALL_STATE(260)] = 8315,
+  [SMALL_STATE(261)] = 8323,
+  [SMALL_STATE(262)] = 8331,
+  [SMALL_STATE(263)] = 8339,
+  [SMALL_STATE(264)] = 8347,
+  [SMALL_STATE(265)] = 8355,
+  [SMALL_STATE(266)] = 8363,
+  [SMALL_STATE(267)] = 8371,
+  [SMALL_STATE(268)] = 8379,
+  [SMALL_STATE(269)] = 8387,
+  [SMALL_STATE(270)] = 8395,
+  [SMALL_STATE(271)] = 8403,
+  [SMALL_STATE(272)] = 8411,
+  [SMALL_STATE(273)] = 8419,
+  [SMALL_STATE(274)] = 8427,
+  [SMALL_STATE(275)] = 8435,
+  [SMALL_STATE(276)] = 8443,
+  [SMALL_STATE(277)] = 8451,
+  [SMALL_STATE(278)] = 8459,
+  [SMALL_STATE(279)] = 8467,
+  [SMALL_STATE(280)] = 8475,
+  [SMALL_STATE(281)] = 8483,
+  [SMALL_STATE(282)] = 8491,
+  [SMALL_STATE(283)] = 8499,
+  [SMALL_STATE(284)] = 8507,
+  [SMALL_STATE(285)] = 8515,
+  [SMALL_STATE(286)] = 8523,
+  [SMALL_STATE(287)] = 8531,
+  [SMALL_STATE(288)] = 8539,
+  [SMALL_STATE(289)] = 8547,
+  [SMALL_STATE(290)] = 8555,
+  [SMALL_STATE(291)] = 8563,
+  [SMALL_STATE(292)] = 8571,
+  [SMALL_STATE(293)] = 8579,
+  [SMALL_STATE(294)] = 8587,
+  [SMALL_STATE(295)] = 8595,
+  [SMALL_STATE(296)] = 8603,
+  [SMALL_STATE(297)] = 8611,
+  [SMALL_STATE(298)] = 8619,
+  [SMALL_STATE(299)] = 8627,
+  [SMALL_STATE(300)] = 8635,
+  [SMALL_STATE(301)] = 8643,
+  [SMALL_STATE(302)] = 8651,
+  [SMALL_STATE(303)] = 8659,
+  [SMALL_STATE(304)] = 8667,
+  [SMALL_STATE(305)] = 8675,
+  [SMALL_STATE(306)] = 8683,
+  [SMALL_STATE(307)] = 8691,
+  [SMALL_STATE(308)] = 8699,
+  [SMALL_STATE(309)] = 8707,
+  [SMALL_STATE(310)] = 8715,
+  [SMALL_STATE(311)] = 8723,
+  [SMALL_STATE(312)] = 8731,
+  [SMALL_STATE(313)] = 8739,
+  [SMALL_STATE(314)] = 8747,
+  [SMALL_STATE(315)] = 8755,
+  [SMALL_STATE(316)] = 8763,
+  [SMALL_STATE(317)] = 8771,
+  [SMALL_STATE(318)] = 8779,
+  [SMALL_STATE(319)] = 8787,
+  [SMALL_STATE(320)] = 8795,
+  [SMALL_STATE(321)] = 8803,
+  [SMALL_STATE(322)] = 8811,
+  [SMALL_STATE(323)] = 8819,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -15777,418 +15734,418 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(296),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(244),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(264),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(221),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(245),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(250),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(236),
-  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
-  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(201),
-  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
-  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(153),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
-  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(136),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(251),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(255),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
-  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
-  [57] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(43),
-  [60] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(250),
-  [63] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(19),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0),
-  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(98),
-  [71] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(112),
-  [74] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(167),
-  [77] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(236),
-  [80] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(113),
-  [83] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(201),
-  [86] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(118),
-  [89] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(153),
-  [92] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(204),
-  [95] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(136),
-  [98] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(108),
-  [101] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(251),
-  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(255),
-  [107] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(143),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
-  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
-  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [118] = {.entry = {.count = 1, .reusable = false}}, SHIFT(318),
-  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(86),
-  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
-  [124] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
-  [126] = {.entry = {.count = 1, .reusable = false}}, SHIFT(148),
-  [128] = {.entry = {.count = 1, .reusable = false}}, SHIFT(309),
-  [130] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
-  [132] = {.entry = {.count = 1, .reusable = false}}, SHIFT(214),
-  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
-  [136] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
-  [138] = {.entry = {.count = 1, .reusable = false}}, SHIFT(215),
-  [140] = {.entry = {.count = 1, .reusable = false}}, SHIFT(125),
-  [142] = {.entry = {.count = 1, .reusable = false}}, SHIFT(126),
-  [144] = {.entry = {.count = 1, .reusable = false}}, SHIFT(306),
-  [146] = {.entry = {.count = 1, .reusable = false}}, SHIFT(323),
-  [148] = {.entry = {.count = 1, .reusable = false}}, SHIFT(146),
-  [150] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(40),
-  [153] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(318),
-  [156] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(86),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__namespace_members, 2, 0, 0),
-  [161] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(122),
-  [164] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(148),
-  [167] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(309),
-  [170] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(123),
-  [173] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(214),
-  [176] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(124),
-  [179] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(110),
-  [182] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(215),
-  [185] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(125),
-  [188] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(126),
-  [191] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(306),
-  [194] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(323),
-  [197] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(146),
-  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
-  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
-  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [208] = {.entry = {.count = 1, .reusable = false}}, SHIFT(216),
-  [210] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
-  [212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(320),
-  [216] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [218] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
-  [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
-  [222] = {.entry = {.count = 1, .reusable = false}}, SHIFT(313),
-  [224] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
-  [226] = {.entry = {.count = 1, .reusable = false}}, SHIFT(218),
-  [228] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
-  [230] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [232] = {.entry = {.count = 1, .reusable = false}}, SHIFT(217),
-  [234] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
-  [236] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [238] = {.entry = {.count = 1, .reusable = false}}, SHIFT(310),
-  [240] = {.entry = {.count = 1, .reusable = false}}, SHIFT(324),
-  [242] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [246] = {.entry = {.count = 1, .reusable = false}}, SHIFT(230),
-  [248] = {.entry = {.count = 1, .reusable = false}}, SHIFT(181),
-  [250] = {.entry = {.count = 1, .reusable = false}}, SHIFT(305),
-  [252] = {.entry = {.count = 1, .reusable = false}}, SHIFT(184),
-  [254] = {.entry = {.count = 1, .reusable = false}}, SHIFT(210),
-  [256] = {.entry = {.count = 1, .reusable = false}}, SHIFT(186),
-  [258] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
-  [260] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
-  [262] = {.entry = {.count = 1, .reusable = false}}, SHIFT(195),
-  [264] = {.entry = {.count = 1, .reusable = false}}, SHIFT(196),
-  [266] = {.entry = {.count = 1, .reusable = false}}, SHIFT(322),
-  [268] = {.entry = {.count = 1, .reusable = false}}, SHIFT(197),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(259),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(302),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(269),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(293),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(317),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(126),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(161),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(264),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(136),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(227),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(139),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(171),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(202),
+  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(141),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(256),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(291),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(290),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(294),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
+  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(40),
+  [66] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(293),
+  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(20),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(102),
+  [77] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(126),
+  [80] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(161),
+  [83] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(264),
+  [86] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(136),
+  [89] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(227),
+  [92] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(139),
+  [95] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(171),
+  [98] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(202),
+  [101] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(141),
+  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(110),
+  [107] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(256),
+  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(291),
+  [113] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__dictionary_members, 2, 0, 0), SHIFT_REPEAT(122),
+  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [118] = {.entry = {.count = 1, .reusable = false}}, SHIFT(316),
+  [120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [124] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
+  [126] = {.entry = {.count = 1, .reusable = false}}, SHIFT(200),
+  [128] = {.entry = {.count = 1, .reusable = false}}, SHIFT(307),
+  [130] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [132] = {.entry = {.count = 1, .reusable = false}}, SHIFT(219),
+  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
+  [136] = {.entry = {.count = 1, .reusable = false}}, SHIFT(109),
+  [138] = {.entry = {.count = 1, .reusable = false}}, SHIFT(220),
+  [140] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
+  [142] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [144] = {.entry = {.count = 1, .reusable = false}}, SHIFT(304),
+  [146] = {.entry = {.count = 1, .reusable = false}}, SHIFT(321),
+  [148] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [152] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(41),
+  [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(316),
+  [158] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(87),
+  [161] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__namespace_members, 2, 0, 0),
+  [163] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(112),
+  [166] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(200),
+  [169] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(307),
+  [172] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(113),
+  [175] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(219),
+  [178] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(114),
+  [181] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(109),
+  [184] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(220),
+  [187] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(116),
+  [190] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(118),
+  [193] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(304),
+  [196] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(321),
+  [199] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__namespace_members, 2, 0, 0), SHIFT_REPEAT(119),
+  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
+  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
+  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [208] = {.entry = {.count = 1, .reusable = false}}, SHIFT(221),
+  [210] = {.entry = {.count = 1, .reusable = false}}, SHIFT(142),
+  [212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(318),
+  [216] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [218] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(311),
+  [222] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [224] = {.entry = {.count = 1, .reusable = false}}, SHIFT(223),
+  [226] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [228] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [230] = {.entry = {.count = 1, .reusable = false}}, SHIFT(222),
+  [232] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [234] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [236] = {.entry = {.count = 1, .reusable = false}}, SHIFT(308),
+  [238] = {.entry = {.count = 1, .reusable = false}}, SHIFT(322),
+  [240] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [242] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [246] = {.entry = {.count = 1, .reusable = false}}, SHIFT(314),
+  [248] = {.entry = {.count = 1, .reusable = false}}, SHIFT(164),
+  [250] = {.entry = {.count = 1, .reusable = false}}, SHIFT(303),
+  [252] = {.entry = {.count = 1, .reusable = false}}, SHIFT(165),
+  [254] = {.entry = {.count = 1, .reusable = false}}, SHIFT(215),
+  [256] = {.entry = {.count = 1, .reusable = false}}, SHIFT(166),
+  [258] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
+  [260] = {.entry = {.count = 1, .reusable = false}}, SHIFT(216),
+  [262] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
+  [264] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
+  [266] = {.entry = {.count = 1, .reusable = false}}, SHIFT(320),
+  [268] = {.entry = {.count = 1, .reusable = false}}, SHIFT(169),
   [270] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__dictionary_member_rest, 3, 0, 5),
   [272] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__dictionary_member_rest, 3, 0, 5),
-  [274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__dictionary_member_rest, 4, 0, 5),
-  [276] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__dictionary_member_rest, 4, 0, 5),
-  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__dictionary_member_rest, 4, 0, 9),
-  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__dictionary_member_rest, 4, 0, 9),
+  [274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__dictionary_member_rest, 4, 0, 9),
+  [276] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__dictionary_member_rest, 4, 0, 9),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__dictionary_member_rest, 4, 0, 5),
+  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__dictionary_member_rest, 4, 0, 5),
   [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_member, 2, 0, 6),
   [284] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_member, 2, 0, 6),
   [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_member, 1, 0, 2),
   [288] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_member, 1, 0, 2),
-  [290] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_const_statement, 6, 0, 13),
-  [292] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_const_statement, 6, 0, 13),
+  [290] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_rest, 5, 0, 0),
+  [292] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_operation_rest, 5, 0, 0),
   [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_regular_operation, 2, 0, 0),
   [296] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_regular_operation, 2, 0, 0),
-  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_member, 1, 0, 0),
-  [300] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_member, 1, 0, 0),
-  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_rest, 4, 0, 0),
-  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_operation_rest, 4, 0, 0),
-  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_rest, 5, 0, 0),
-  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_operation_rest, 5, 0, 0),
+  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_const_statement, 6, 0, 13),
+  [300] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_const_statement, 6, 0, 13),
+  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_member, 1, 0, 0),
+  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_member, 1, 0, 0),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_rest, 4, 0, 0),
+  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_operation_rest, 4, 0, 0),
   [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_list, 3, 0, 0),
   [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_extended_attribute_list, 3, 0, 0),
   [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_list, 4, 0, 0),
   [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_extended_attribute_list, 4, 0, 0),
-  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(178),
-  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(149),
-  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_type, 2, 0, 0),
-  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_type, 2, 0, 0),
-  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
-  [330] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_type, 1, 0, 0),
-  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_type, 1, 0, 0),
-  [334] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [336] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_type, 1, 0, 0),
-  [338] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_type, 1, 0, 0),
-  [340] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_primitive_type, 1, 0, 0),
-  [342] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_primitive_type, 1, 0, 0),
-  [344] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 1, 0, 0),
-  [346] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 1, 0, 0),
-  [348] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [350] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 1, 0, 0),
-  [352] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1, 0, 0),
-  [354] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_type, 1, 0, 0),
-  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_type, 1, 0, 0),
+  [318] = {.entry = {.count = 1, .reusable = false}}, SHIFT(156),
+  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(230),
+  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_type, 1, 0, 0),
+  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_type, 1, 0, 0),
+  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [330] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_type, 2, 0, 0),
+  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_type, 2, 0, 0),
+  [334] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
+  [336] = {.entry = {.count = 1, .reusable = false}}, SHIFT(226),
+  [338] = {.entry = {.count = 1, .reusable = false}}, SHIFT(138),
+  [340] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 1, 0, 0),
+  [342] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 1, 0, 0),
+  [344] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [346] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 1, 0, 0),
+  [348] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 1, 0, 0),
+  [350] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [352] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_primitive_type, 1, 0, 0),
+  [354] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_primitive_type, 1, 0, 0),
+  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_type, 2, 0, 0),
+  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_type, 2, 0, 0),
   [360] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_buffer_related_type, 1, 0, 0),
   [362] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_buffer_related_type, 1, 0, 0),
-  [364] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 4, 0, 0),
-  [366] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 4, 0, 0),
-  [368] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [370] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_type, 3, 0, 0),
-  [372] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_type, 3, 0, 0),
-  [374] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_type, 2, 0, 0),
-  [376] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_type, 2, 0, 0),
-  [378] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_union_type, 3, 0, 0),
-  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_union_type, 3, 0, 0),
-  [382] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_record_type, 6, 0, 0),
-  [384] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_record_type, 6, 0, 0),
-  [386] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 5, 0, 0),
-  [388] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 5, 0, 0),
-  [390] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [392] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 2, 0, 0),
-  [394] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 2, 0, 0),
-  [396] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_promise_type, 4, 0, 0),
-  [398] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_promise_type, 4, 0, 0),
-  [400] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 2, 0, 0),
-  [402] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 2, 0, 0),
-  [404] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 6, 0, 0),
-  [406] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 6, 0, 0),
-  [408] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type_with_extended_attributes, 2, 0, 0),
-  [410] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type_with_extended_attributes, 1, 0, 0),
-  [412] = {.entry = {.count = 1, .reusable = false}}, SHIFT(248),
-  [414] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
-  [416] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
-  [418] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(296),
-  [421] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(244),
-  [424] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(264),
-  [427] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(221),
-  [430] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(14),
-  [433] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(245),
-  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
-  [438] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
-  [440] = {.entry = {.count = 1, .reusable = false}}, SHIFT(240),
-  [442] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 7, 0, 9),
-  [444] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 7, 0, 9),
-  [446] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__definition, 1, 0, 0),
-  [448] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__definition, 1, 0, 0),
-  [450] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 6, 0, 9),
-  [452] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 6, 0, 9),
-  [454] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 7, 0, 5),
-  [456] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 7, 0, 5),
-  [458] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_typedef_statement, 4, 0, 0),
-  [460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_typedef_statement, 4, 0, 0),
-  [462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_includes_statement, 4, 0, 4),
-  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_includes_statement, 4, 0, 4),
-  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 5, 0, 5),
-  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 5, 0, 5),
+  [364] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_integer_type, 3, 0, 0),
+  [366] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_type, 3, 0, 0),
+  [368] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 4, 0, 0),
+  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 4, 0, 0),
+  [372] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [374] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 5, 0, 0),
+  [376] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 5, 0, 0),
+  [378] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [380] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_record_type, 6, 0, 0),
+  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_record_type, 6, 0, 0),
+  [384] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_type, 1, 0, 0),
+  [386] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string_type, 1, 0, 0),
+  [388] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_union_type, 3, 0, 0),
+  [390] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_union_type, 3, 0, 0),
+  [392] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_float_type, 1, 0, 0),
+  [394] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_type, 1, 0, 0),
+  [396] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 2, 0, 0),
+  [398] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 2, 0, 0),
+  [400] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_promise_type, 4, 0, 0),
+  [402] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_promise_type, 4, 0, 0),
+  [404] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type, 2, 0, 0),
+  [406] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type, 2, 0, 0),
+  [408] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_distinguishable_type, 6, 0, 0),
+  [410] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_distinguishable_type, 6, 0, 0),
+  [412] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type_with_extended_attributes, 2, 0, 0),
+  [414] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_type_with_extended_attributes, 1, 0, 0),
+  [416] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
+  [418] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [420] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [424] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [426] = {.entry = {.count = 1, .reusable = false}}, SHIFT(147),
+  [428] = {.entry = {.count = 1, .reusable = false}}, SHIFT(236),
+  [430] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [432] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [434] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(259),
+  [437] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(302),
+  [440] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(269),
+  [443] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(211),
+  [446] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
+  [449] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(261),
+  [452] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [454] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__definition, 1, 0, 0),
+  [456] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__definition, 1, 0, 0),
+  [458] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 7, 0, 5),
+  [460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 7, 0, 5),
+  [462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 6, 0, 5),
+  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 6, 0, 5),
+  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 6, 0, 5),
+  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 6, 0, 5),
   [470] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 7, 0, 9),
   [472] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 7, 0, 9),
-  [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [476] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 5, 0, 5),
-  [478] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 5, 0, 5),
-  [480] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 6, 0, 5),
-  [482] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 6, 0, 5),
-  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum_statement, 6, 0, 5),
-  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_enum_statement, 6, 0, 5),
-  [488] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
-  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [492] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
-  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 6, 0, 5),
-  [496] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 6, 0, 5),
-  [498] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 6, 0, 9),
-  [500] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 6, 0, 9),
-  [502] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [504] = {.entry = {.count = 1, .reusable = false}}, SHIFT(258),
-  [506] = {.entry = {.count = 1, .reusable = false}}, SHIFT(260),
-  [508] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
-  [510] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
-  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [514] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, 0, 11),
-  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
-  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
-  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [538] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [540] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 2, 0, 0),
-  [544] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_name, 1, 0, 0),
-  [548] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
-  [550] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
-  [552] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [554] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
-  [556] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__enum_value_list, 2, 0, 0),
-  [558] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type_with_extended_attributes, 2, 0, 0),
-  [560] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier_list, 2, 0, 0),
-  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [564] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default, 2, 0, 0),
-  [566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [568] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_ident, 3, 0, 4),
-  [570] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_value, 2, 0, 0),
-  [572] = {.entry = {.count = 1, .reusable = false}}, SHIFT(140),
-  [574] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0),
-  [576] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
-  [579] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extended_attribute_list_repeat1, 2, 0, 0), SHIFT_REPEAT(101),
-  [582] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extended_attribute_list_repeat1, 2, 0, 0),
-  [584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_identifier_list_repeat1, 2, 0, 0),
-  [586] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_identifier_list_repeat1, 2, 0, 0), SHIFT_REPEAT(231),
-  [589] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [591] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
-  [593] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
-  [595] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [597] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [599] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
-  [601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_name_keyword, 1, 0, 0),
-  [603] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__enum_value_list_repeat1, 2, 0, 0), SHIFT_REPEAT(284),
-  [606] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__enum_value_list_repeat1, 2, 0, 0),
-  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [614] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 1, 0, 0),
-  [616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
-  [618] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__enum_value_list, 1, 0, 0),
-  [620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier_list, 1, 0, 0),
-  [622] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [624] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [626] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type_with_extended_attributes, 1, 0, 0),
-  [628] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_value, 1, 0, 0),
-  [630] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_no_args, 1, 0, 1),
-  [632] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [634] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [636] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [638] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [640] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
-  [642] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [644] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, 0, 12),
-  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_ident_list, 5, 0, 8),
-  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
-  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [652] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [654] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_wildcard, 3, 0, 8),
-  [656] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [662] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [666] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [668] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [670] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_named_arg_list, 6, 0, 4),
-  [672] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 2, 0, 10),
-  [674] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
-  [676] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
-  [678] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_union_or_expression, 3, 0, 7),
-  [680] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [682] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_union_member_type, 1, 0, 0),
-  [684] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 4, 0, 11),
-  [686] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute, 1, 0, 0),
-  [688] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__enum_value_list, 3, 0, 0),
-  [690] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
-  [692] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
-  [694] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [696] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [698] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [700] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
-  [702] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [704] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
-  [706] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_literal, 1, 0, 0),
-  [708] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_literal, 1, 0, 0),
-  [710] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_literal, 1, 0, 0),
-  [712] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [714] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [718] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
-  [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
-  [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
-  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [734] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
-  [736] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [738] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [740] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [742] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
-  [744] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [746] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_name_keyword, 1, 0, 0),
-  [748] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [750] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_name, 1, 0, 0),
-  [752] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inheritance, 2, 0, 3),
-  [754] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
-  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [758] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
-  [760] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [762] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [764] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [766] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [768] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [770] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [772] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [774] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [776] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [780] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [782] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
-  [784] = {.entry = {.count = 1, .reusable = true}}, SHIFT(297),
+  [474] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 7, 0, 9),
+  [476] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 7, 0, 9),
+  [478] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_enum_statement, 6, 0, 5),
+  [480] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_enum_statement, 6, 0, 5),
+  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 6, 0, 9),
+  [484] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 6, 0, 9),
+  [486] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 6, 0, 9),
+  [488] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 6, 0, 9),
+  [490] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_typedef_statement, 4, 0, 0),
+  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_typedef_statement, 4, 0, 0),
+  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_includes_statement, 4, 0, 4),
+  [496] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_includes_statement, 4, 0, 4),
+  [498] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_statement, 5, 0, 5),
+  [500] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_statement, 5, 0, 5),
+  [502] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_namespace_statement, 5, 0, 5),
+  [504] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_namespace_statement, 5, 0, 5),
+  [506] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [508] = {.entry = {.count = 1, .reusable = false}}, SHIFT(241),
+  [510] = {.entry = {.count = 1, .reusable = false}}, SHIFT(245),
+  [512] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
+  [514] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
+  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [526] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [538] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [540] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, 0, 11),
+  [542] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [544] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_integer_literal, 1, 0, 0),
+  [548] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_value, 1, 0, 0),
+  [550] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_literal, 1, 0, 0),
+  [552] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_float_literal, 1, 0, 0),
+  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default, 2, 0, 0),
+  [556] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
+  [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [562] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__enum_value_list, 1, 0, 0),
+  [564] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 2, 0, 0),
+  [566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [568] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_name_keyword, 1, 0, 0),
+  [570] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier_list, 2, 0, 0),
+  [572] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
+  [574] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type_with_extended_attributes, 1, 0, 0),
+  [576] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_value, 2, 0, 0),
+  [578] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0),
+  [580] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
+  [583] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_identifier_list_repeat1, 2, 0, 0),
+  [585] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_identifier_list_repeat1, 2, 0, 0), SHIFT_REPEAT(233),
+  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
+  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
+  [592] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
+  [594] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [596] = {.entry = {.count = 1, .reusable = false}}, SHIFT(134),
+  [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
+  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [610] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__enum_value_list, 2, 0, 0),
+  [612] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_no_args, 1, 0, 1),
+  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_ident, 3, 0, 4),
+  [622] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_extended_attribute_list_repeat1, 2, 0, 0), SHIFT_REPEAT(91),
+  [625] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_extended_attribute_list_repeat1, 2, 0, 0),
+  [627] = {.entry = {.count = 1, .reusable = false}}, SHIFT(130),
+  [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [631] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [633] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier_list, 1, 0, 0),
+  [635] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__enum_value_list_repeat1, 2, 0, 0), SHIFT_REPEAT(244),
+  [638] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__enum_value_list_repeat1, 2, 0, 0),
+  [640] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 1, 0, 0),
+  [642] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_type_with_extended_attributes, 2, 0, 0),
+  [644] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__enum_value_list, 3, 0, 0),
+  [646] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
+  [648] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [650] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_named_arg_list, 6, 0, 4),
+  [652] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 4, 0, 11),
+  [654] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute, 1, 0, 0),
+  [656] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_union_or_expression, 3, 0, 7),
+  [658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [662] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_wildcard, 3, 0, 8),
+  [664] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
+  [666] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [668] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [670] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [672] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [674] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_extended_attribute_ident_list, 5, 0, 8),
+  [676] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [678] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [680] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [682] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [690] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_union_member_type, 1, 0, 0),
+  [692] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 3, 0, 12),
+  [694] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [696] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument, 2, 0, 10),
+  [698] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [700] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
+  [702] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inheritance, 2, 0, 3),
+  [704] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [706] = {.entry = {.count = 1, .reusable = true}}, SHIFT(295),
+  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [710] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [712] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [714] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_operation_name_keyword, 1, 0, 0),
+  [716] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [718] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [724] = {.entry = {.count = 1, .reusable = true}}, SHIFT(300),
+  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
+  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [734] = {.entry = {.count = 1, .reusable = true}}, SHIFT(296),
+  [736] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
+  [738] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [740] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [742] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [744] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [746] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [748] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
+  [750] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [752] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [754] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [758] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [760] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [762] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
+  [764] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [766] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
+  [768] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [770] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [772] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [774] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [776] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
+  [780] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [782] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [784] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
   [786] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [788] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [790] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
-  [792] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [794] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [788] = {.entry = {.count = 1, .reusable = true}}, SHIFT(301),
+  [790] = {.entry = {.count = 1, .reusable = true}}, SHIFT(297),
+  [792] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [794] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
   [796] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [798] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [800] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [802] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [804] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [806] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [808] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
-  [810] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
-  [812] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [814] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
-  [816] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [818] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [820] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [822] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [824] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [826] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [828] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [830] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
-  [832] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [834] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [836] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [838] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [798] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [800] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [802] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [804] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [806] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [808] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [810] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [812] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
+  [814] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [816] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [818] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [820] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [822] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [824] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
+  [826] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [828] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [830] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [832] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
+  [834] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [836] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [838] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
   [840] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [842] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [844] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [842] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [844] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
   [846] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [848] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [850] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [852] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [854] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
-  [856] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
-  [858] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
-  [860] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [862] = {.entry = {.count = 1, .reusable = true}}, SHIFT(314),
-  [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [866] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [868] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [870] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [872] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [848] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [850] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [852] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [854] = {.entry = {.count = 1, .reusable = true}}, SHIFT(305),
+  [856] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [858] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
+  [860] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [862] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
+  [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [866] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
+  [868] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [870] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [872] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/enum_statement.txt
+++ b/test/corpus/enum_statement.txt
@@ -3,9 +3,9 @@ Enum statement
 ============================================
 
 enum HardwareAcceleration {
-  "no-preference",
-  "prefer-hardware",
-  "prefer-software",
+	"no-preference",
+	"prefer-hardware",
+	"prefer-software",
 };
 
 ----

--- a/test/corpus/namespace_statement.txt
+++ b/test/corpus/namespace_statement.txt
@@ -3,8 +3,8 @@ Namespace statement with operations
 ============================================
 
 namespace CSS {
-    CSSUnitValue number(double value);
-    CSSUnitValue percent(double value);
+	CSSUnitValue number(double value);
+	CSSUnitValue percent(double value);
 };
 
 ----
@@ -18,32 +18,30 @@ namespace CSS {
 					(distinguishable_type
 						(identifier)))
 				(operation_rest
-					(operation_name
-						(identifier))
+					(identifier)
 					(argument_list
 						(argument
 							(type
 								(distinguishable_type
 									(primitive_type
 										(float_type))))
-							(argument_name
-								(identifier)))))))
+							(identifier))))))
 		(namespace_member
 			(regular_operation
 				(type
 					(distinguishable_type
 						(identifier)))
 				(operation_rest
-					(operation_name
-						(identifier))
+					(identifier)
 					(argument_list
 						(argument
 							(type
 								(distinguishable_type
 									(primitive_type
 										(float_type))))
-							(argument_name
-								(identifier)))))))))
+							(identifier))))))
+	)
+)
 
 ============================================
 Partial namespace statement


### PR DESCRIPTION
To simplify the AST, the following nodes are now hidden:
- OperationName
- ArgumentName